### PR TITLE
Edited json.Unmarshal error debug message

### DIFF
--- a/server.go
+++ b/server.go
@@ -81,7 +81,7 @@ func (c *Conn) readPump() {
 		msg := &Message{}
 
 		if err := json.Unmarshal(message, &msg); err != nil {
-			log.Debugf("Unknown message: %s", message)
+			log.Debugf("Unable to parse message due to invalid JSON. \nMessage:\n  %s\nError:\n  %s", message, err)
 		} else {
 			log.Debugf("Client message: %s", msg)
 			switch msg.Command {

--- a/subscriber.go
+++ b/subscriber.go
@@ -28,7 +28,7 @@ func (s *Subscriber) run() {
 			log.Debugf("[Redis] channel %s: message: %s\n", v.Channel, v.Data)
 			msg := &StreamMessage{}
 			if err := json.Unmarshal(v.Data, &msg); err != nil {
-				log.Debugf("Unknown message: %s", v.Data)
+				log.Debugf("Unable to parse message due to invalid JSON. \nMessage:\n  %s\nError:\n  %s", v.Data, err)
 			} else {
 				log.Debugf("Broadcast %v", msg)
 				hub.stream_broadcast <- msg


### PR DESCRIPTION
When I was debugging Anycablebility I ran into this error and this "Unknown message" debug message confused me. It wasn't clear what exactly "unknown" means in this case. When I dug into the sources, I found out it was simply because I haven't encoded `identifier`.

I edited this message so it gives some clue about what exactly is wrong. This is how it looks in logs:
```
Auth status:SUCCESS identifiers:"{}" transmissions:"{\"type\":\"welcome\"}"
Increment ping
Ping count 1
Register connection &{0xc42012e800 {} map[] 0xc42019d4a0}
Unable to parse message due to invalid JSON.
Message:
  {"command":"subscribe","identifier":{"channel":"JustChannel"}}
Error:
  json: cannot unmarshal object into Go struct field Message.identifier of type string
2017/03/24 21:49:40 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 0.0.0.0:50051: getsockopt: connection refused"; Reconnecting to {"0.0.0.0:50051" <nil>}
2017/03/24 21:49:40 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 0.0.0.0:50051: getsockopt: connection refused"; Reconnecting to {"0.0.0.0:50051" <nil>}
```