### PR TITLE
Omit empty type

### DIFF
--- a/app.go
+++ b/app.go
@@ -23,7 +23,7 @@ type Message struct {
 }
 
 type Reply struct {
-	Type       string      `json:"type"`
+	Type       string      `json:"type,omitempty"`
 	Identifier string      `json:"identifier"`
 	Message    interface{} `json:"message"`
 }


### PR DESCRIPTION
`Reply` messages were encoding by default `type` set to empty string and it was causing issues since the `type` if not present should be omitted.