### PR TITLE
Add ability to specify metrics host bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## master
 
-## 0.6.0-preview5
-
 - Add `--metrics_host` option.
 
 ## 0.6.0-preview4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.6.0-preview5
+
+- Add `--metrics_host` option.
+
 ## 0.6.0-preview4
 
 - Fixed memory leak (caused by leaking mutex goroutines).

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Anycable-Go provides useful statistical information about the service (such as a
 
 To enable a HTTP endpoint to serve [Prometheus](https://prometheus.io)-compatible metrics (disabled by default) you must specify `--metrics_http` option (e.g. `--metrics_http="/metrics"`).
 
-You can also change a listnening port through `--metrics_port` option (by default the same as the main (websocket) server port, i.e. using the same server).
+You can also change a listening port and listening host through `--metrics_port` and `--metrics_host` options respectively (by default the same as the main (websocket) server port and host, i.e. using the same server).
 
 The exported metrics format is the following:
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -60,6 +60,7 @@ func init() {
 
 	fs.BoolVar(&defaults.MetricsLog, "metrics_log", false, "")
 	fs.IntVar(&defaults.MetricsLogInterval, "metrics_log_interval", 15, "")
+	fs.StringVar(&defaults.MetricsHost, "metrics_host", "", "")
 	fs.IntVar(&defaults.MetricsPort, "metrics_port", 0, "")
 	fs.StringVar(&defaults.MetricsHTTP, "metrics_http", "", "")
 
@@ -122,6 +123,7 @@ The flags are:
   --metrics_log            Enable metrics logging (with info level), default: false, env: ANYCABLE_METRICS_LOG
   --metrics_log_interval   Specify how often flush metrics logs (in seconds), defailt: 15, env: ANYCABLE_METRICS_LOG_INTERVAL
   --metrics_http           Enable HTTP metrics endpoint at the specified path, default: "" (disabled), env: ANYCABLE_METRICS_PATH
+  --metrics_host           Server host for metrics endpoint, default: the same as for main server, env: ANYCABLE_METRICS_HOST
   --metrics_port           Server port for metrics endpoint, default: the same as for main server, env: ANYCABLE_METRICS_PORT
 
   -h                       This help screen

--- a/cmd/anycable-go/main.go
+++ b/cmd/anycable-go/main.go
@@ -102,7 +102,11 @@ func main() {
 
 		if config.MetricsPort != config.Port {
 			port := strconv.Itoa(config.MetricsPort)
-			metricsServer = buildServer(node, config.Host, port, &config.SSL)
+			host := config.Host
+			if config.MetricsHost != "" {
+				host = config.MetricsHost
+			}
+			metricsServer = buildServer(node, host, port, &config.SSL)
 			ctx.Infof("Serve metrics at %s:%s%s", config.Host, port, config.MetricsHTTP)
 		} else {
 			ctx.Infof("Serve metrics at %s", config.MetricsHTTP)

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	MetricsLog         bool
 	MetricsLogInterval int
 	MetricsHTTP        string
+	MetricsHost        string
 	MetricsPort        int
 }
 


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

<!--
    Please ensure your PR is ready:

    - Include tests for this change (if appropriate)
    - Add Changelog entry
    - Update documentation for this change (if appropriate)
-->
This PR adds ability to bind metrics server to another address. It will be helpful if you want to protect metrics with basic auth and reverse proxying
