### PR TITLE
[WIP] mRuby commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,10 @@ prepare-mruby:
 build-mruby:
 	env $(GOBUILD) -tags mrb -o $(OUTPUT) cmd/anycable-go/main.go
 
-build-all-mruby:
-	env $(GOBUILD) -tags mrb -o "dist/anycable-go-$(VERSION)-mrb-macos-amd64" cmd/anycable-go/main.go
-	docker run --rm -v $(PWD):/go/src/github.com/anycable/anycable-go -w /go/src/github.com/anycable/anycable-go -e OUTPUT="dist/anycable-go-$(VERSION)-mrb-linux-amd64" amd64/golang:1.10 make build
+build-mruby-linux:
+	docker run --rm -v $(PWD):/go/src/github.com/anycable/anycable-go -w /go/src/github.com/anycable/anycable-go -e OUTPUT="dist/anycable-go-$(VERSION)-mrb-linux-amd64" amd64/golang:1.10 make build-mruby
+
+build-all-mruby: build-mruby build-mruby-linux
 
 build-clean:
 	rm -rf ./dist

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ prepare-cross-mruby:
 prepare-mruby:
 	(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make)
 
+build-mruby:
+	env $(GOBUILD) -tags mrb -o $(OUTPUT) cmd/anycable-go/main.go
+
 build-all-mruby:
 	env $(GOBUILD) -tags mrb -o "dist/anycable-go-$(VERSION)-mrb-macos-amd64" cmd/anycable-go/main.go
 	docker run --rm -v $(PWD):/go/src/github.com/anycable/anycable-go -w /go/src/github.com/anycable/anycable-go -e OUTPUT="dist/anycable-go-$(VERSION)-mrb-linux-amd64" amd64/golang:1.10 make build

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ test:
 		github.com/anycable/anycable-go/pool \
 		github.com/anycable/anycable-go/pubsub \
 		github.com/anycable/anycable-go/rpc \
+		github.com/anycable/anycable-go/rpc_cached \
 		github.com/anycable/anycable-go/server \
 		github.com/anycable/anycable-go/metrics \
 		github.com/anycable/anycable-go/mrb \

--- a/etc/build_config.rb
+++ b/etc/build_config.rb
@@ -23,6 +23,9 @@ MRuby::Build.new do |conf|
 
   # include the default GEMs
   conf.gembox 'default'
+  conf.gem mgem: 'mruby-json'
+  conf.gem mgem: 'mruby-regexp-pcre'
+
   # C compiler settings
   # conf.cc do |cc|
   #   cc.command = ENV['CC'] || 'gcc'

--- a/etc/json_printer.rb
+++ b/etc/json_printer.rb
@@ -1,0 +1,5 @@
+module MetricsFormatter
+  def self.call(data)
+    data.to_json
+  end
+end

--- a/metrics/custom_printer_test.go
+++ b/metrics/custom_printer_test.go
@@ -1,0 +1,62 @@
+// +build darwin,mrb linux,mrb
+
+package metrics
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anycable/anycable-go/mrb"
+)
+
+func TestPrintGC(t *testing.T) {
+	engine := mrb.NewEngine()
+
+	engine.LoadString(
+		`
+		module MetricsFormatter
+			def self.new_hash; {}; end
+
+			def self.call(data)
+				filtered_data = data.select do |k, v|
+					!k.start_with?("_")
+				end
+
+				filtered_data.to_json
+			end
+		end
+		`,
+	)
+
+	mod := engine.VM.Module("MetricsFormatter")
+
+	modValue := mod.MrbValue(engine.VM)
+
+	printer := &RubyPrinter{mrbModule: modValue, engine: engine}
+
+	engine.VM.FullGC()
+
+	origObjects := engine.VM.LiveObjectCount()
+
+	snapshot := map[string]int64{"a": 123, "_b": 432, "_f": 321}
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	printer.Print(snapshot)
+
+	assert.Contains(t, buf.String(), "{\"a\":123}")
+
+	newObjects := engine.VM.LiveObjectCount()
+
+	if origObjects != newObjects {
+		t.Fatalf("Object count was not what was expected after action call: %d %d", origObjects, newObjects)
+	}
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -253,6 +253,7 @@ func (c *Controller) parseCommandResponse(response interface{}, err error) (*nod
 			StopAllStreams: r.StopStreams,
 			Streams:        r.Streams,
 			Transmissions:  r.Transmissions,
+			Broadcasts:     []string{},
 		}
 
 		if r.Status.String() == "SUCCESS" {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1,0 +1,57 @@
+package rpc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	rpcHost = os.Getenv("TEST_RPC")
+)
+
+func TestActionPerform(t *testing.T) {
+	if rpcHost == "" {
+		t.Skip("RPC server is not running")
+	}
+
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{RPCHost: "0.0.0.0:50051"}
+	controller := NewController(c, m)
+	controller.Start()
+
+	_, err := controller.Perform(
+		"test",
+		"{}",
+		"{\"channel\":\"BenchmarkChannel\"}",
+		"{\"action\":\"echo\",\"text\":\"hello\"}",
+	)
+
+	assert.Nil(t, err)
+}
+
+func BenchmarkActionPerform(b *testing.B) {
+	if rpcHost == "" {
+		b.Skip("RPC server is not running")
+	}
+
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{RPCHost: "0.0.0.0:50051"}
+	controller := NewController(c, m)
+
+	controller.Start()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		controller.Perform(
+			"test",
+			"{}",
+			"{\"channel\":\"BenchmarkChannel\"}",
+			"{\"action\":\"echo\",\"text\":\"hello\"}",
+		)
+	}
+}

--- a/rpc_cached/mcache.go
+++ b/rpc_cached/mcache.go
@@ -4,6 +4,7 @@ package rpc_cached
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/anycable/anycable-go/mrb"
 	"github.com/anycable/anycable-go/node"
@@ -123,6 +124,7 @@ func (c *MCache) Get(channel string, action string) (maction *MAction) {
 // MAction is a signle cached channel method
 type MAction struct {
 	compiled *mruby.MrbValue
+	mu       sync.Mutex
 }
 
 // NewMAction compiles a channel method within mruby VM
@@ -155,6 +157,9 @@ func NewMAction(cache *MCache, channel string, source string) (*MAction, error) 
 
 // Perform executes action within mruby
 func (m *MAction) Perform(data string) (*node.CommandResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	result, err := m.compiled.Call("perform", mruby.String(data))
 
 	if err != nil {

--- a/rpc_cached/mcache.go
+++ b/rpc_cached/mcache.go
@@ -91,6 +91,35 @@ func NewMCache(mengine *mrb.Engine) (*MCache, error) {
 	}, nil
 }
 
+// Put compiles method and put it in the cache
+func (c *MCache) Put(channel string, action string, source string) (err error) {
+	// TODO: check for existence, add lock
+	var maction *MAction
+
+	maction, err = NewMAction(c, channel, source)
+
+	if err != nil {
+		return
+	}
+
+	if _, ok := c.store[channel]; !ok {
+		c.store[channel] = make(map[string]*MAction)
+	}
+
+	c.store[channel][action] = maction
+	return
+}
+
+// Get returns cached action for the channel if any
+func (c *MCache) Get(channel string, action string) (maction *MAction) {
+	if _, ok := c.store[channel]; !ok {
+		return
+	}
+
+	maction, _ = c.store[channel][action]
+	return
+}
+
 // MAction is a signle cached channel method
 type MAction struct {
 	compiled *mruby.MrbValue

--- a/rpc_cached/mcache.go
+++ b/rpc_cached/mcache.go
@@ -1,0 +1,168 @@
+// +build darwin,mrb linux,mrb
+
+package rpc_cached
+
+import (
+	"log"
+	"strings"
+
+	"github.com/anycable/anycable-go/mrb"
+	"github.com/anycable/anycable-go/node"
+	mruby "github.com/mitchellh/go-mruby"
+)
+
+// MCallResult is an interface to decode mruby call
+type MCallResult struct {
+	Streams        []string `mruby:"streams"`
+	StopAllStreams bool     `mruby:"stop_all_streams"`
+	Transmissions  []string `mruby:"transmissions"`
+}
+
+// MCache is a cache of mruby compiled channels methods
+type MCache struct {
+	engine *mrb.Engine
+	store  map[string]map[string]*MAction
+}
+
+var (
+	// MrbCache is a global channels methods cache
+	MrbCache *MCache
+)
+
+// InitCache creates global cache
+func InitCache() {
+	if MrbCache != nil {
+		return
+	}
+
+	var err error
+	MrbCache, err = NewMCache(mrb.DefaultEngine())
+
+	if err != nil {
+		log.Fatalf("Failed to initialize MrbCache: %s", err)
+	}
+}
+
+// NewMCache builds a new cache struct for mruby engine
+func NewMCache(mengine *mrb.Engine) (*MCache, error) {
+	// Build base channel class
+	err := mengine.LoadString(
+		`
+	module AnyCable
+		class Channel
+			class Result
+				attr_reader :streams, :transmissions
+				attr_accessor :stop_all_streams
+
+				def initialize
+					@streams = []
+					@transmissions = []
+					@stop_all_streams = false
+				end
+
+				def to_gomruby
+					{
+						streams: streams,
+						transmissions: transmissions,
+						stop_all_streams: stop_all_streams
+					}
+				end
+			end
+
+			class << self
+				attr_reader :identifier
+
+				def identify(channel)
+					@identifier = { channel: channel }.to_json
+				end
+
+				def perform(json_data)
+					data = JSON.parse(json_data)
+					new.tap do |channel|
+						channel.send(data.fetch('action'), data)
+					end.result
+				end
+			end
+
+			attr_reader :result
+
+			def initialize
+				@result = Result.new
+			end
+
+			def transmit(data)
+				result.transmissions << {
+					identifier: self.class.identifier,
+					message: data
+				}.to_json
+			end
+		end
+	end
+	`,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &MCache{
+		engine: mengine,
+		store:  make(map[string]map[string]*MAction),
+	}, nil
+}
+
+// MAction is a signle cached channel method
+type MAction struct {
+	compiled *mruby.MrbValue
+}
+
+// NewMAction compiles a channel method within mruby VM
+func NewMAction(engine *mrb.Engine, channel string, source string) (*MAction, error) {
+	var buf strings.Builder
+
+	channelClass := "CachedChannel_" + channel
+
+	buf.WriteString(
+		"class " + channelClass + " < AnyCable::Channel\n",
+	)
+	buf.WriteString("identify \"" + channel + "\"\n")
+	buf.WriteString(source + "\n")
+	buf.WriteString("end\n")
+
+	err := engine.LoadString(buf.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	mchannel := engine.VM.Class(channelClass, nil)
+
+	mchannelValue := mchannel.MrbValue(engine.VM)
+
+	return &MAction{compiled: mchannelValue}, nil
+}
+
+// Perform executes action within mruby
+func (m *MAction) Perform(data string) (*node.CommandResult, error) {
+	result, err := m.compiled.Call("perform", mruby.String(data))
+
+	if err != nil {
+		return nil, err
+	}
+
+	decoded := MCallResult{}
+
+	err = mruby.Decode(&decoded, result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	res := &node.CommandResult{
+		Transmissions:  decoded.Transmissions,
+		StopAllStreams: decoded.StopAllStreams,
+		Streams:        decoded.Streams,
+	}
+
+	return res, nil
+}

--- a/rpc_cached/mcache.go
+++ b/rpc_cached/mcache.go
@@ -3,7 +3,6 @@
 package rpc_cached
 
 import (
-	"log"
 	"strings"
 
 	"github.com/anycable/anycable-go/mrb"
@@ -22,25 +21,6 @@ type MCallResult struct {
 type MCache struct {
 	engine *mrb.Engine
 	store  map[string]map[string]*MAction
-}
-
-var (
-	// MrbCache is a global channels methods cache
-	MrbCache *MCache
-)
-
-// InitCache creates global cache
-func InitCache() {
-	if MrbCache != nil {
-		return
-	}
-
-	var err error
-	MrbCache, err = NewMCache(mrb.DefaultEngine())
-
-	if err != nil {
-		log.Fatalf("Failed to initialize MrbCache: %s", err)
-	}
 }
 
 // NewMCache builds a new cache struct for mruby engine
@@ -117,7 +97,7 @@ type MAction struct {
 }
 
 // NewMAction compiles a channel method within mruby VM
-func NewMAction(engine *mrb.Engine, channel string, source string) (*MAction, error) {
+func NewMAction(cache *MCache, channel string, source string) (*MAction, error) {
 	var buf strings.Builder
 
 	channelClass := "CachedChannel_" + channel
@@ -128,6 +108,8 @@ func NewMAction(engine *mrb.Engine, channel string, source string) (*MAction, er
 	buf.WriteString("identify \"" + channel + "\"\n")
 	buf.WriteString(source + "\n")
 	buf.WriteString("end\n")
+
+	engine := cache.engine
 
 	err := engine.LoadString(buf.String())
 

--- a/rpc_cached/mcache_test.go
+++ b/rpc_cached/mcache_test.go
@@ -37,9 +37,19 @@ func TestMAction(t *testing.T) {
 
 	assert.Nil(t, err)
 
+	cache.engine.VM.FullGC()
+
+	origObjects := cache.engine.VM.LiveObjectCount()
+
 	res, err := maction.Perform("{\"action\":\"echo\",\"text\":\"hello\"}")
 
 	assert.Nil(t, err)
+
+	newObjects := cache.engine.VM.LiveObjectCount()
+
+	if origObjects != newObjects {
+		t.Fatalf("Object count was not what was expected after action call: %d %d", origObjects, newObjects)
+	}
 
 	identifier := "{\\\"channel\\\":\\\"BenchmarkChannel\\\"}"
 

--- a/rpc_cached/mcache_test.go
+++ b/rpc_cached/mcache_test.go
@@ -1,0 +1,40 @@
+// +build darwin,mrb linux,mrb
+
+package rpc_cached
+
+import (
+	"testing"
+
+	"github.com/anycable/anycable-go/mrb"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	InitCache()
+}
+
+func TestMAction(t *testing.T) {
+	maction, err := NewMAction(
+		mrb.DefaultEngine(),
+		"BenchmarkChannel",
+		`
+		def echo(data)
+			transmit response: data
+		end
+		`,
+	)
+
+	assert.Nil(t, err)
+
+	res, err := maction.Perform("{\"action\":\"echo\",\"text\":\"hello\"}")
+
+	assert.Nil(t, err)
+
+	identifier := "{\\\"channel\\\":\\\"BenchmarkChannel\\\"}"
+
+	assert.Empty(t, res.Streams)
+	assert.False(t, res.Disconnect)
+	assert.False(t, res.StopAllStreams)
+	assert.Equal(t, []string{"{\"identifier\":\"" + identifier + "\",\"message\":{\"response\":{\"action\":\"echo\",\"text\":\"hello\"}}}"}, res.Transmissions)
+}

--- a/rpc_cached/mcache_test.go
+++ b/rpc_cached/mcache_test.go
@@ -3,6 +3,7 @@
 package rpc_cached
 
 import (
+	"log"
 	"testing"
 
 	"github.com/anycable/anycable-go/mrb"
@@ -10,13 +11,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	cache *MCache
+)
+
 func init() {
-	InitCache()
+	var err error
+	cache, err = NewMCache(mrb.DefaultEngine())
+
+	if err != nil {
+		log.Fatalf("Failed to initialize mruby cache: %s", err)
+	}
 }
 
 func TestMAction(t *testing.T) {
 	maction, err := NewMAction(
-		mrb.DefaultEngine(),
+		cache,
 		"BenchmarkChannel",
 		`
 		def echo(data)

--- a/rpc_cached/rpc_cached.go
+++ b/rpc_cached/rpc_cached.go
@@ -1,0 +1,1 @@
+package rpc_cached

--- a/rpc_cached/rpc_cached.go
+++ b/rpc_cached/rpc_cached.go
@@ -1,3 +1,5 @@
+// +build darwin,mrb linux,mrb
+
 package rpc_cached
 
 import (

--- a/rpc_cached/rpc_cached.go
+++ b/rpc_cached/rpc_cached.go
@@ -87,6 +87,14 @@ func (c *Controller) Perform(sid string, id string, channel string, data string)
 	}
 
 	if maction := c.cache.Get(identifier.Channel, msg.Action); maction != nil {
+		c.metrics.Counter(metricsCacheHit).Inc()
+		log.WithFields(
+			log.Fields{
+				"sid":     sid,
+				"context": "rpc",
+				"channel": identifier.Channel,
+				"action":  msg.Action,
+			}).Debugf("cache hit")
 		return maction.Perform(data)
 	}
 

--- a/rpc_cached/rpc_cached.go
+++ b/rpc_cached/rpc_cached.go
@@ -1,1 +1,68 @@
 package rpc_cached
+
+import (
+	"github.com/anycable/anycable-go/mrb"
+
+	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/metrics"
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/rpc"
+	"github.com/apex/log"
+)
+
+const (
+	metricsCacheHit = "rpc_cache_hit"
+)
+
+// Controller implements node.Controller interface for gRPC
+type Controller struct {
+	rpc     *rpc.Controller
+	cache   *MCache
+	metrics *metrics.Metrics
+	log     *log.Entry
+}
+
+// NewController builds new Controller from config
+func NewController(config *config.Config, metrics *metrics.Metrics) *Controller {
+	metrics.RegisterCounter(metricsCacheHit, "The total number of RPC cache hits")
+
+	rpc := rpc.NewController(config, metrics)
+	return &Controller{log: log.WithField("context", "rpc"), metrics: metrics, rpc: rpc}
+}
+
+// Start initializes RPC connection pool
+func (c *Controller) Start() (err error) {
+	err = c.rpc.Start()
+	c.cache, err = NewMCache(mrb.DefaultEngine())
+	return
+}
+
+// Shutdown closes connections
+func (c *Controller) Shutdown() error {
+	return c.rpc.Shutdown()
+}
+
+// Authenticate performs Connect RPC call
+func (c *Controller) Authenticate(path string, headers *map[string]string) (string, []string, error) {
+	return c.rpc.Authenticate(path, headers)
+}
+
+// Subscribe performs Command RPC call with "subscribe" command
+func (c *Controller) Subscribe(sid string, id string, channel string) (*node.CommandResult, error) {
+	return c.rpc.Subscribe(sid, id, channel)
+}
+
+// Unsubscribe performs Command RPC call with "unsubscribe" command
+func (c *Controller) Unsubscribe(sid string, id string, channel string) (*node.CommandResult, error) {
+	return c.rpc.Unsubscribe(sid, id, channel)
+}
+
+// Perform performs Command RPC call with "perform" command
+func (c *Controller) Perform(sid string, id string, channel string, data string) (*node.CommandResult, error) {
+	return c.rpc.Perform(sid, id, channel, data)
+}
+
+// Disconnect performs disconnect RPC call
+func (c *Controller) Disconnect(sid string, id string, subscriptions []string, path string, headers *map[string]string) error {
+	return c.rpc.Disconnect(sid, id, subscriptions, path, headers)
+}

--- a/rpc_cached/rpc_cached_test.go
+++ b/rpc_cached/rpc_cached_test.go
@@ -31,7 +31,7 @@ func TestCachedPerform(t *testing.T) {
 	m := metrics.NewMetrics(nil, 10)
 	c := &config.Config{}
 	controller := NewController(c, m)
-	controller.Start()
+	controller.cache = cache
 
 	res, err := controller.Perform(
 		"test",
@@ -46,7 +46,7 @@ func TestCachedPerform(t *testing.T) {
 
 	assert.Equal(
 		t,
-		[]string{"{\"identifier\":\"" + identifier + "\",\"message\":{\"action\":\"echo\",\"text\":\"hello\"}}"},
+		[]string{"{\"identifier\":\"" + identifier + "\",\"message\":{\"response\":{\"action\":\"echo\",\"text\":\"hello\"}}}"},
 		res.Transmissions,
 	)
 }
@@ -55,7 +55,7 @@ func TestConcurrentCachedPerform(t *testing.T) {
 	m := metrics.NewMetrics(nil, 10)
 	c := &config.Config{}
 	controller := NewController(c, m)
-	controller.Start()
+	controller.cache = cache
 
 	var wg sync.WaitGroup
 
@@ -88,7 +88,7 @@ func BenchmarkCachedActionEcho(b *testing.B) {
 	m := metrics.NewMetrics(nil, 10)
 	c := &config.Config{}
 	controller := NewController(c, m)
-	controller.Start()
+	controller.cache = cache
 
 	for i := 0; i < b.N; i++ {
 		controller.Perform(

--- a/rpc_cached/rpc_cached_test.go
+++ b/rpc_cached/rpc_cached_test.go
@@ -27,6 +27,34 @@ func init() {
 	if err != nil {
 		log.Fatalf("Failed to compile channel method: %s", err)
 	}
+
+	err = cache.Put(
+		"BenchmarkChannel",
+		"subscribed",
+		`
+		def subscribed
+			stream_from "all"
+			transmit "welcome"
+		end
+		`,
+	)
+
+	if err != nil {
+		log.Fatalf("Failed to compile channel method: %s", err)
+	}
+
+	err = cache.Put(
+		"BenchmarkChannel",
+		"unsubscribed",
+		`
+		def unsubscribed
+		end
+		`,
+	)
+
+	if err != nil {
+		log.Fatalf("Failed to compile channel method: %s", err)
+	}
 }
 
 func TestCachedPerform(t *testing.T) {
@@ -84,6 +112,64 @@ func TestConcurrentCachedPerform(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, int64(0), errorsCount)
+}
+
+func TestCachedSubscribed(t *testing.T) {
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{}
+	controller := NewController(c, m)
+	controller.cache = cache
+
+	res, err := controller.Subscribe(
+		"test",
+		"",
+		"{\"channel\":\"BenchmarkChannel\"}",
+	)
+
+	assert.Nil(t, err)
+
+	identifier := "{\\\"channel\\\":\\\"BenchmarkChannel\\\"}"
+
+	assert.Equal(
+		t,
+		[]string{"all"},
+		res.Streams,
+	)
+	assert.Equal(
+		t,
+		[]string{
+			"{\"identifier\":\"" + identifier + "\",\"type\":\"confirm_subscription\"}",
+			"{\"identifier\":\"" + identifier + "\",\"message\":\"welcome\"}",
+		},
+		res.Transmissions,
+	)
+}
+
+func TestCachedUnsubscribed(t *testing.T) {
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{}
+	controller := NewController(c, m)
+	controller.cache = cache
+
+	res, err := controller.Unsubscribe(
+		"test",
+		"",
+		"{\"channel\":\"BenchmarkChannel\"}",
+	)
+
+	assert.Nil(t, err)
+
+	assert.True(t, res.StopAllStreams)
+	// Not implemented in Action Cable yet: https://github.com/rails/rails/pull/24900
+	//
+	// identifier := "{\\\"channel\\\":\\\"BenchmarkChannel\\\"}"
+	// assert.Equal(
+	// 	t,
+	// 	[]string{
+	// 		"{\"identifier\":\"" + identifier + "\",\"type\":\"confirm_unsubscribe\"}"
+	// 	},
+	// 	res.Transmissions,
+	// )
 }
 
 func BenchmarkCachedActionEcho(b *testing.B) {

--- a/rpc_cached/rpc_cached_test.go
+++ b/rpc_cached/rpc_cached_test.go
@@ -90,6 +90,10 @@ func BenchmarkCachedActionEcho(b *testing.B) {
 	controller := NewController(c, m)
 	controller.cache = cache
 
+	cache.engine.VM.FullGC()
+
+	origObjects := cache.engine.VM.LiveObjectCount()
+
 	for i := 0; i < b.N; i++ {
 		controller.Perform(
 			"test",
@@ -97,5 +101,11 @@ func BenchmarkCachedActionEcho(b *testing.B) {
 			"{\"channel\":\"BenchmarkChannel\"}",
 			"{\"action\":\"echo\",\"text\":\"hello\"}",
 		)
+	}
+
+	newObjects := cache.engine.VM.LiveObjectCount()
+
+	if origObjects != newObjects {
+		b.Fatalf("Object count was not what was expected after action call: %d %d", origObjects, newObjects)
 	}
 }

--- a/rpc_cached/rpc_cached_test.go
+++ b/rpc_cached/rpc_cached_test.go
@@ -1,0 +1,58 @@
+package rpc_cached
+
+import (
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	err := cache.Put(
+		"BenchmarkChannel",
+		"echo",
+		`
+		def echo(data)
+			transmit response: data
+		end
+		`,
+	)
+
+	if err != nil {
+		log.Fatalf("Failed to compile channel method: %s", err)
+	}
+}
+
+func TestCachedPerform(t *testing.T) {
+	controller := &Controller{cache: cache}
+
+	res, err := controller.Perform(
+		"test",
+		"",
+		"{\"channel\":\"BenchmarkChannel\"}",
+		"{\"action\":\"echo\",\"text\":\"hello\"}",
+	)
+
+	assert.Nil(t, err)
+
+	identifier := "{\\\"channel\\\":\\\"BenchmarkChannel\\\"}"
+
+	assert.Equal(
+		t,
+		[]string{"{\"identifier\":\"" + identifier + "\",\"message\":{\"response\":{\"action\":\"echo\",\"text\":\"hello\"}}}"},
+		res.Transmissions,
+	)
+}
+
+func BenchmarkCachedActionPerform(b *testing.B) {
+	controller := &Controller{cache: cache}
+
+	for i := 0; i < b.N; i++ {
+		controller.Perform(
+			"test",
+			"",
+			"{\"channel\":\"BenchmarkChannel\"}",
+			"{\"action\":\"echo\",\"text\":\"hello\"}",
+		)
+	}
+}

--- a/rpc_cached/rpc_cached_test.go
+++ b/rpc_cached/rpc_cached_test.go
@@ -1,8 +1,12 @@
 package rpc_cached
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/metrics"
 	"github.com/apex/log"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,7 +28,10 @@ func init() {
 }
 
 func TestCachedPerform(t *testing.T) {
-	controller := &Controller{cache: cache}
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{}
+	controller := NewController(c, m)
+	controller.Start()
 
 	res, err := controller.Perform(
 		"test",
@@ -39,13 +46,49 @@ func TestCachedPerform(t *testing.T) {
 
 	assert.Equal(
 		t,
-		[]string{"{\"identifier\":\"" + identifier + "\",\"message\":{\"response\":{\"action\":\"echo\",\"text\":\"hello\"}}}"},
+		[]string{"{\"identifier\":\"" + identifier + "\",\"message\":{\"action\":\"echo\",\"text\":\"hello\"}}"},
 		res.Transmissions,
 	)
 }
 
-func BenchmarkCachedActionPerform(b *testing.B) {
-	controller := &Controller{cache: cache}
+func TestConcurrentCachedPerform(t *testing.T) {
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{}
+	controller := NewController(c, m)
+	controller.Start()
+
+	var wg sync.WaitGroup
+
+	errorsCount := int64(0)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			_, err := controller.Perform(
+				"test",
+				"",
+				"{\"channel\":\"BenchmarkChannel\"}",
+				"{\"action\":\"echo\",\"text\":\"hello\"}",
+			)
+
+			if err != nil {
+				atomic.AddInt64(&errorsCount, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(0), errorsCount)
+}
+
+func BenchmarkCachedActionEcho(b *testing.B) {
+	m := metrics.NewMetrics(nil, 10)
+	c := &config.Config{}
+	controller := NewController(c, m)
+	controller.Start()
 
 	for i := 0; i < b.N; i++ {
 		controller.Perform(

--- a/rpc_cached/rpc_cached_test.go
+++ b/rpc_cached/rpc_cached_test.go
@@ -1,3 +1,5 @@
+// +build darwin,mrb linux,mrb
+
 package rpc_cached
 
 import (

--- a/rpc_cached/rpc_cached_unsupported.go
+++ b/rpc_cached/rpc_cached_unsupported.go
@@ -1,0 +1,17 @@
+// +build !darwin,!linux !mrb
+
+package rpc_cached
+
+import (
+	"log"
+
+	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/metrics"
+	"github.com/anycable/anycable-go/rpc"
+)
+
+// NewController builds new Controller from config
+func NewController(config *config.Config, metrics *metrics.Metrics) *rpc.Controller {
+	log.Fatal("Cached (mRuby) RPC controller is not supported!")
+	return rpc.NewController(config, metrics)
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

Add ability to perform Action Cable commands within `anycable-go` itself without calling RPC server.

That would allows us to increase RPS (requests-per-second) for RPC bridge (see [the benchmarks](https://github.com/anycable/anycable/blob/master/benchmarks/2018-05-27-rpc-bench.md)).

To implement this _caching_ we fetch (_not implemented yet_) the source code of the method and compile it within the embedded mRuby VM.

#### Benchmarks

Running `anycable-go` on the same machine as RPC server:

```
# websocket-bench echo
rpc_cached           95per-rtt:   5ms
rpc                  95per-rtt:   30ms

# controller.Perform
rpc_cached           0.05ms
rpc                  0.7ms
```

### TODO

Features:
- [ ] Embed mRuby sources (https://github.com/gobuffalo/packr ?)
- [ ] Fetch method source from RPC
- [ ] Detect _cacheable_\* commands
- [ ] Cache invalidation

\* Not every channel command could be cached, of course. We need a way to either automatically guest whether it's possible to "move" the method to mRuby or to provide an API to mark such methods in the Ruby source code.

Misc:
- [x] mRuby memory profiling (GC arena save/restore?)
- [ ] Run benchmarks/stress test
- [ ] Add Changelog entry
- [ ] Update documentation for this change
