### PR TITLE
Use Golang specific build tag `mrb` to manage mruby feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,6 @@ jobs:
     <<: *golang_image
     working_directory: /go/src/github.com/anycable/anycable-go/
     environment:
-      CGO_ENABLED: "0"
       GOOS: linux
       GOARCH: amd64
     steps:
@@ -159,7 +158,7 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Linux amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/anycable-go-test" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/anycable-go-test" cmd/anycable-go/main.go
     - save_cache:
         key: binary-for-anyt-test-{{ .Revision }}
         paths: /tmp/anycable-go-test
@@ -169,7 +168,6 @@ jobs:
       xcode: "10.0.0"
     environment:
       GOPATH: /Users/distiller/go
-      CGO_ENABLED: 1
       GOARCH: amd64
     working_directory: /Users/distiller/go/src/github.com/anycable/anycable-go/
     steps:
@@ -189,7 +187,7 @@ jobs:
           bash -c "(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make libmruby.a)"
     - run:
         name: Build Darwin amd64 binary (with mruby)
-        command: /usr/local/go/bin/go build -ldflags "-s -w -X main.version=0.6.0-preview5" -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-mrb-dawrin-amd64" cmd/anycable-go/main.go
+        command: /usr/local/go/bin/go build -ldflags "-s -w -X main.version=0.6.0-preview5" -tags mrb -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-mrb-dawrin-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: darwin-mruby-{{ .Revision }}
         paths: /tmp/dist/
@@ -198,23 +196,22 @@ jobs:
     <<: *golang_image
     working_directory: /go/src/github.com/anycable/anycable-go/
     environment:
-      CGO_ENABLED: "0"
       GOOS: linux
     steps:
     - attach_workspace:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Linux i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-386" cmd/anycable-go/main.go
     - run:
         name: Building Linux amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-amd64" cmd/anycable-go/main.go
     - run:
         name: Building Linux arm binary
-        command: env GOARCH=arm go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm" cmd/anycable-go/main.go
+        command: env GOARCH=arm go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm" cmd/anycable-go/main.go
     - run:
         name: Building Linux arm binary
-        command: env GOARCH=arm64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm64" cmd/anycable-go/main.go
+        command: env GOARCH=arm64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm64" cmd/anycable-go/main.go
     - save_cache:
         key: linux-nomruby-{{ .Revision }}
         paths: /tmp/dist/
@@ -223,17 +220,16 @@ jobs:
     <<: *golang_image
     working_directory: /go/src/github.com/anycable/anycable-go/
     environment:
-      CGO_ENABLED: "0"
       GOOS: windows
     steps:
     - attach_workspace:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Windows i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
     - run:
         name: Building Windows amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: windows-{{ .Revision }}
         paths: /tmp/dist/
@@ -242,17 +238,16 @@ jobs:
     <<: *golang_image
     working_directory: /go/src/github.com/anycable/anycable-go/
     environment:
-      CGO_ENABLED: "0"
       GOOS: darwin
     steps:
     - attach_workspace:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Darwin i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
     - run:
         name: Building Darwin amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: darwin-nomruby-{{ .Revision }}
         paths: /tmp/dist/
@@ -261,20 +256,19 @@ jobs:
     <<: *golang_image
     working_directory: /go/src/github.com/anycable/anycable-go/
     environment:
-      CGO_ENABLED: "0"
       GOOS: freebsd
     steps:
     - attach_workspace:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building FreeBSD i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-386" cmd/anycable-go/main.go
     - run:
         name: Building FreeBSD amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-amd64" cmd/anycable-go/main.go
     - run:
         name: Building FreeBSD arm binary
-        command: env GOARCH=arm go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-arm" cmd/anycable-go/main.go
+        command: env GOARCH=arm go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-arm" cmd/anycable-go/main.go
     - save_cache:
         key: freebsd-{{ .Revision }}
         paths: /tmp/dist/
@@ -283,7 +277,6 @@ jobs:
     <<: *golang_image
     working_directory: /go/src/github.com/anycable/anycable-go/
     environment:
-      CGO_ENABLED: "1"
       GOOS: linux
       GOARCH: amd64
     steps:
@@ -291,7 +284,7 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Linux amd64 binary
-        command: env go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -installsuffix cgo -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-mrb-linux-amd64" cmd/anycable-go/main.go
+        command: env go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -tags mrb -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-mrb-linux-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: linux-mruby-{{ .Revision }}
         paths: /tmp/dist/

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ default: prepare build
 install:
 	go install ./...
 
+install-with-mruby:
+	go install -tags mrb ./...
+
 build:
-	env CGO_ENABLED=1 go build -ldflags "-s -w -X main.version=$(VERSION)" -o $(OUTPUT) cmd/anycable-go/main.go
+	env go build -tags mrb -ldflags "-s -w -X main.version=$(VERSION)" -o $(OUTPUT) cmd/anycable-go/main.go
 
 prepare-cross-mruby:
 	(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CROSS_OS=linux MRUBY_CONFIG=../../../../../../etc/build_config.rb make)
@@ -28,25 +31,25 @@ prepare-mruby:
 	(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make)
 
 build-linux:
-	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-linux-386" cmd/anycable-go/main.go
+	env GOOS=linux GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-386" cmd/anycable-go/main.go
 
 build-all-mruby:
-	env CGO_ENABLED=1 go build -ldflags "-s -w -X main.version=$(VERSION)" -o "dist/anycable-go-$(VERSION)-mrb-macos-amd64" cmd/anycable-go/main.go
+	env go build -ldflags "-s -w -X main.version=$(VERSION)" -tags mrb -o "dist/anycable-go-$(VERSION)-mrb-macos-amd64" cmd/anycable-go/main.go
 	docker run --rm -v $(PWD):/go/src/github.com/anycable/anycable-go -w /go/src/github.com/anycable/anycable-go -e OUTPUT="dist/anycable-go-$(VERSION)-mrb-linux-amd64" amd64/golang:1.10 make build
 
 build-all:
 	rm -rf ./dist
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-linux-arm" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-linux-arm64" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-linux-386" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-linux-amd64" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-win-386" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-win-amd64" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-macos-386" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-macos-amd64" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=freebsd GOARCH=arm go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-freebsd-arm" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=freebsd GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-freebsd-386" cmd/anycable-go/main.go
-	env CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o "dist/anycable-go-$(VERSION)-freebsd-amd64" cmd/anycable-go/main.go
+	env GOOS=linux GOARCH=arm go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-arm" cmd/anycable-go/main.go
+	env GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-arm64" cmd/anycable-go/main.go
+	env GOOS=linux GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-386" cmd/anycable-go/main.go
+	env GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-amd64" cmd/anycable-go/main.go
+	env GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-win-386" cmd/anycable-go/main.go
+	env GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-win-amd64" cmd/anycable-go/main.go
+	env GOOS=darwin GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-macos-386" cmd/anycable-go/main.go
+	env GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-macos-amd64" cmd/anycable-go/main.go
+	env GOOS=freebsd GOARCH=arm go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-freebsd-arm" cmd/anycable-go/main.go
+	env GOOS=freebsd GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-freebsd-386" cmd/anycable-go/main.go
+	env GOOS=freebsd GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-freebsd-amd64" cmd/anycable-go/main.go
 
 s3-deploy:
 	aws s3 cp --acl=public-read ./dist/anycable-go-$(VERSION)-linux-amd64 "s3://anycable/builds/$(VERSION)/anycable-go-$(VERSION)-heroku"
@@ -61,7 +64,7 @@ docker-release: dockerize
 	docker push "anycable/anycable-go:$(VERSION)"
 
 dockerize:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.version=$(VERSION)" -a -installsuffix cgo -o .docker/anycable-go cmd/anycable-go/main.go
+	GOOS=linux go build -ldflags "-X main.version=$(VERSION)" -a -o .docker/anycable-go cmd/anycable-go/main.go
 	docker build -t "anycable/anycable-go:$(VERSION)" .
 
 # Run server
@@ -72,7 +75,7 @@ build-protos:
 	protoc --proto_path=./etc --go_out=plugins=grpc:./protos ./etc/rpc.proto
 
 test:
-	go test github.com/anycable/anycable-go/cli \
+	go test -tags mrb github.com/anycable/anycable-go/cli \
 		github.com/anycable/anycable-go/config \
 		github.com/anycable/anycable-go/node \
 		github.com/anycable/anycable-go/pool \

--- a/Readme.md
+++ b/Readme.md
@@ -19,13 +19,13 @@ brew install anycable/anycable/anycable-go
 Of course, you can install it from source too:
 
 ```shell
-CGO_ENABLED=0 go get -u -f github.com/anycable/anycable-go/cmd/anycable-go
+go get -u -f github.com/anycable/anycable-go/cmd/anycable-go
 ```
 
-**NOTE:** right now it's not possible to build `anycable-go` with mruby support using the command above (that's why we added `CGO_ENABLED=0`). To install `anycable-go` with mruby from source try:
+**NOTE:** right now it's not possible to build `anycable-go` with mruby support using the command above. To install `anycable-go` with mruby from source try:
 
 ```
-go get -d -u -f github.com/anycable/anycable-go/cmd/anycable-go && (cd $GOPATH/src/github.com/anycable/anycable-go && make prepare-mruby install)
+go get -d -u -f github.com/anycable/anycable-go/cmd/anycable-go && (cd $GOPATH/src/github.com/anycable/anycable-go && make prepare-mruby install-with-mruby)
 ```
 
 ## Upgrade

--- a/cmd/anycable-go/main.go
+++ b/cmd/anycable-go/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anycable/anycable-go/cli"
 	"github.com/anycable/anycable-go/config"
 	"github.com/anycable/anycable-go/metrics"
+	"github.com/anycable/anycable-go/mrb"
 	"github.com/anycable/anycable-go/node"
 	"github.com/anycable/anycable-go/pubsub"
 	"github.com/anycable/anycable-go/rpc"
@@ -27,6 +28,10 @@ var (
 func init() {
 	if version == "" {
 		version = "0.6.0-unknown"
+
+		if mrb.Supported() {
+			version = version + "-mrb"
+		}
 	}
 }
 

--- a/metrics/custom_printer.go
+++ b/metrics/custom_printer.go
@@ -1,4 +1,4 @@
-// +build darwin,cgo linux,cgo
+// +build darwin,mrb linux,mrb
 
 package metrics
 

--- a/metrics/custom_printer_unsupported.go
+++ b/metrics/custom_printer_unsupported.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux !cgo
+// +build !darwin,!linux !mrb
 
 package metrics
 

--- a/mrb/mrb.go
+++ b/mrb/mrb.go
@@ -1,4 +1,4 @@
-// +build darwin,cgo linux,cgo
+// +build darwin,mrb linux,mrb
 
 package mrb
 

--- a/mrb/mrb_test.go
+++ b/mrb/mrb_test.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,mrb linux,mrb
 
 package mrb
 

--- a/mrb/mrb_unsupported.go
+++ b/mrb/mrb_unsupported.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux !cgo
+// +build !darwin,!linux !mrb
 
 package mrb
 


### PR DESCRIPTION
From now on, we don't need to pass hacky CGO_ENABLED env variable
to disable mruby support. It means that it's possible to
install binary with convenient `go get` and it works for all
the users despite their platform specifics.

Besides, these more minor changes were made:

- default version value respects mruby support with `mrb` postfix
- changes are reflected in Makefile and CI
- removed useless `-installsuffix` argument for all build commands
