### PR TITLE
Reduce binary size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Linux amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/anycable-go-test" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/anycable-go-test" cmd/anycable-go/main.go
     - save_cache:
         key: binary-for-anyt-test-{{ .Revision }}
         paths: /tmp/anycable-go-test
@@ -202,16 +202,16 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Linux i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-386" cmd/anycable-go/main.go
     - run:
         name: Building Linux amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-amd64" cmd/anycable-go/main.go
     - run:
         name: Building Linux arm binary
-        command: env GOARCH=arm go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm" cmd/anycable-go/main.go
+        command: env GOARCH=arm go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm" cmd/anycable-go/main.go
     - run:
         name: Building Linux arm binary
-        command: env GOARCH=arm64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm64" cmd/anycable-go/main.go
+        command: env GOARCH=arm64 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-linux-arm64" cmd/anycable-go/main.go
     - save_cache:
         key: linux-nomruby-{{ .Revision }}
         paths: /tmp/dist/
@@ -226,10 +226,10 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Windows i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
     - run:
         name: Building Windows amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: windows-{{ .Revision }}
         paths: /tmp/dist/
@@ -244,10 +244,10 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Darwin i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-386" cmd/anycable-go/main.go
     - run:
         name: Building Darwin amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-win-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: darwin-nomruby-{{ .Revision }}
         paths: /tmp/dist/
@@ -262,13 +262,13 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building FreeBSD i386 binary
-        command: env GOARCH=386 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-386" cmd/anycable-go/main.go
+        command: env GOARCH=386 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-386" cmd/anycable-go/main.go
     - run:
         name: Building FreeBSD amd64 binary
-        command: env GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-amd64" cmd/anycable-go/main.go
+        command: env GOARCH=amd64 go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-amd64" cmd/anycable-go/main.go
     - run:
         name: Building FreeBSD arm binary
-        command: env GOARCH=arm go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-arm" cmd/anycable-go/main.go
+        command: env GOARCH=arm go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-freebsd-arm" cmd/anycable-go/main.go
     - save_cache:
         key: freebsd-{{ .Revision }}
         paths: /tmp/dist/
@@ -284,7 +284,7 @@ jobs:
         at: /go/src/github.com/anycable/anycable-go/
     - run:
         name: Building Linux amd64 binary
-        command: env go build -ldflags "-X main.version=$(git describe --abbrev=0 --tags)" -tags mrb -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-mrb-linux-amd64" cmd/anycable-go/main.go
+        command: env go build -ldflags "-s -w -X main.version=$(git describe --abbrev=0 --tags)" -tags mrb -a -o "/tmp/dist/anycable-go-$(git describe --abbrev=0 --tags)-mrb-linux-amd64" cmd/anycable-go/main.go
     - save_cache:
         key: linux-mruby-{{ .Revision }}
         paths: /tmp/dist/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ else
 PATH := $(subst :,/bin:,$(GOPATH))/bin:$(PATH)
 endif
 
+LD_FLAGS="-s -w -X main.version=$(VERSION)"
+GOBUILD=go build -ldflags $(LD_FLAGS) -a
+
 # Standard build
 default: prepare build
 
@@ -22,7 +25,7 @@ install-with-mruby:
 	go install -tags mrb ./...
 
 build:
-	env go build -tags mrb -ldflags "-s -w -X main.version=$(VERSION)" -o $(OUTPUT) cmd/anycable-go/main.go
+	env go build -tags mrb -ldflags $(LD_FLAGS) -o $(OUTPUT) cmd/anycable-go/main.go
 
 prepare-cross-mruby:
 	(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CROSS_OS=linux MRUBY_CONFIG=../../../../../../etc/build_config.rb make)
@@ -30,26 +33,27 @@ prepare-cross-mruby:
 prepare-mruby:
 	(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make)
 
-build-linux:
-	env GOOS=linux GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-386" cmd/anycable-go/main.go
-
 build-all-mruby:
-	env go build -ldflags "-s -w -X main.version=$(VERSION)" -tags mrb -o "dist/anycable-go-$(VERSION)-mrb-macos-amd64" cmd/anycable-go/main.go
+	env $(GOBUILD) -tags mrb -o "dist/anycable-go-$(VERSION)-mrb-macos-amd64" cmd/anycable-go/main.go
 	docker run --rm -v $(PWD):/go/src/github.com/anycable/anycable-go -w /go/src/github.com/anycable/anycable-go -e OUTPUT="dist/anycable-go-$(VERSION)-mrb-linux-amd64" amd64/golang:1.10 make build
 
-build-all:
+build-clean:
 	rm -rf ./dist
-	env GOOS=linux GOARCH=arm go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-arm" cmd/anycable-go/main.go
-	env GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-arm64" cmd/anycable-go/main.go
-	env GOOS=linux GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-386" cmd/anycable-go/main.go
-	env GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-linux-amd64" cmd/anycable-go/main.go
-	env GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-win-386" cmd/anycable-go/main.go
-	env GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-win-amd64" cmd/anycable-go/main.go
-	env GOOS=darwin GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-macos-386" cmd/anycable-go/main.go
-	env GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-macos-amd64" cmd/anycable-go/main.go
-	env GOOS=freebsd GOARCH=arm go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-freebsd-arm" cmd/anycable-go/main.go
-	env GOOS=freebsd GOARCH=386 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-freebsd-386" cmd/anycable-go/main.go
-	env GOOS=freebsd GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -a -o "dist/anycable-go-$(VERSION)-freebsd-amd64" cmd/anycable-go/main.go
+
+build-linux:
+	env GOOS=linux   GOARCH=386   $(GOBUILD) -o "dist/anycable-go-$(VERSION)-linux-386"     cmd/anycable-go/main.go
+
+build-all: build-clean build-linux
+	env GOOS=linux   GOARCH=arm   $(GOBUILD) -o "dist/anycable-go-$(VERSION)-linux-arm"     cmd/anycable-go/main.go
+	env GOOS=linux   GOARCH=arm64 $(GOBUILD) -o "dist/anycable-go-$(VERSION)-linux-arm64"   cmd/anycable-go/main.go
+	env GOOS=linux   GOARCH=amd64 $(GOBUILD) -o "dist/anycable-go-$(VERSION)-linux-amd64"   cmd/anycable-go/main.go
+	env GOOS=windows GOARCH=386   $(GOBUILD) -o "dist/anycable-go-$(VERSION)-win-386"       cmd/anycable-go/main.go
+	env GOOS=windows GOARCH=amd64 $(GOBUILD) -o "dist/anycable-go-$(VERSION)-win-amd64"     cmd/anycable-go/main.go
+	env GOOS=darwin  GOARCH=386   $(GOBUILD) -o "dist/anycable-go-$(VERSION)-macos-386"     cmd/anycable-go/main.go
+	env GOOS=darwin  GOARCH=amd64 $(GOBUILD) -o "dist/anycable-go-$(VERSION)-macos-amd64"   cmd/anycable-go/main.go
+	env GOOS=freebsd GOARCH=arm   $(GOBUILD) -o "dist/anycable-go-$(VERSION)-freebsd-arm"   cmd/anycable-go/main.go
+	env GOOS=freebsd GOARCH=386   $(GOBUILD) -o "dist/anycable-go-$(VERSION)-freebsd-386"   cmd/anycable-go/main.go
+	env GOOS=freebsd GOARCH=amd64 $(GOBUILD) -o "dist/anycable-go-$(VERSION)-freebsd-amd64" cmd/anycable-go/main.go
 
 s3-deploy:
 	aws s3 cp --acl=public-read ./dist/anycable-go-$(VERSION)-linux-amd64 "s3://anycable/builds/$(VERSION)/anycable-go-$(VERSION)-heroku"


### PR DESCRIPTION
Hi there,

Accidentally, I've noticed that the build process is not ideal - it produces not the smallest possible binaries.

I've fixed that in CI configuration and Makefile, refactored it a little bit.

Before:

```
10M	anycable-go-v0.6.0-preview5-27-gf7c7e77-freebsd-386
12M	anycable-go-v0.6.0-preview5-27-gf7c7e77-freebsd-amd64
10M	anycable-go-v0.6.0-preview5-27-gf7c7e77-freebsd-arm
12M	anycable-go-v0.6.0-preview5-27-gf7c7e77-linux-amd64
10M	anycable-go-v0.6.0-preview5-27-gf7c7e77-linux-arm
11M	anycable-go-v0.6.0-preview5-27-gf7c7e77-linux-arm64
10M	anycable-go-v0.6.0-preview5-27-gf7c7e77-macos-386
12M	anycable-go-v0.6.0-preview5-27-gf7c7e77-macos-amd64
10M	anycable-go-v0.6.0-preview5-27-gf7c7e77-win-386
12M	anycable-go-v0.6.0-preview5-27-gf7c7e77-win-amd64
```

After:

```
7.4M	anycable-go-v0.6.0-preview5-27-gf7c7e77-freebsd-386
8.8M	anycable-go-v0.6.0-preview5-27-gf7c7e77-freebsd-amd64
7.5M	anycable-go-v0.6.0-preview5-27-gf7c7e77-freebsd-arm
8.8M	anycable-go-v0.6.0-preview5-27-gf7c7e77-linux-amd64
7.5M	anycable-go-v0.6.0-preview5-27-gf7c7e77-linux-arm
8.1M	anycable-go-v0.6.0-preview5-27-gf7c7e77-linux-arm64
8.3M	anycable-go-v0.6.0-preview5-27-gf7c7e77-macos-386
9.6M	anycable-go-v0.6.0-preview5-27-gf7c7e77-macos-amd64
7.3M	anycable-go-v0.6.0-preview5-27-gf7c7e77-win-386
8.7M	anycable-go-v0.6.0-preview5-27-gf7c7e77-win-amd64
```

LD_FLAGS tags [explanation](https://golang.org/cmd/link/): 

> -s
>	Omit the symbol table and debug information.
>-w
>	Omit the DWARF symbol table.