### PR TITLE
 Reduce the amount of object allocations during reading sets of metrics 

### DIFF
--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -5,8 +5,8 @@ import "sync/atomic"
 // Counter stores information about something "countable".
 // Store
 type Counter struct {
-	Name              string
-	Desc              string
+	name              string
+	desc              string
 	value             int64
 	lastIntervalValue int64
 	lastIntervalDelta int64
@@ -14,7 +14,17 @@ type Counter struct {
 
 // NewCounter creates new Counter.
 func NewCounter(name string, desc string) *Counter {
-	return &Counter{Name: name, Desc: desc, value: 0}
+	return &Counter{name: name, desc: desc, value: 0}
+}
+
+// Name returns counter name
+func (c *Counter) Name() string {
+	return c.name
+}
+
+// Desc returns counter description
+func (c *Counter) Desc() string {
+	return c.desc
 }
 
 // Value allows to get raw counter value.

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -7,13 +7,23 @@ import (
 // Gauge stores an int value
 type Gauge struct {
 	value int64
-	Name  string
-	Desc  string
+	name  string
+	desc  string
 }
 
 // NewGauge initializes Gauge.
 func NewGauge(name string, desc string) *Gauge {
-	return &Gauge{Name: name, Desc: desc, value: 0}
+	return &Gauge{name: name, desc: desc, value: 0}
+}
+
+// Name returns gauge name
+func (g *Gauge) Name() string {
+	return g.name
+}
+
+// Desc returns gauge description
+func (g *Gauge) Desc() string {
+	return g.desc
 }
 
 // Set gauge value

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -115,22 +115,14 @@ func (m *Metrics) Counter(name string) *Counter {
 	return m.counters[name]
 }
 
-// Counters returns all counters
-func (m *Metrics) Counters() []Counter {
+// EachCounter applies function f(*Gauge) to each gauge in a set
+func (m *Metrics) EachCounter(f func(c *Counter)) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	counters := make([]Counter, len(m.counters))
-
-	i := 0
-
 	for _, counter := range m.counters {
-		dcounter := *counter
-		counters[i] = dcounter
-		i++
+		f(counter)
 	}
-
-	return counters
 }
 
 // Gauge returns gauge by name
@@ -138,22 +130,14 @@ func (m *Metrics) Gauge(name string) *Gauge {
 	return m.gauges[name]
 }
 
-// Gauges returns all gauges
-func (m *Metrics) Gauges() []Gauge {
+// EachGauge applies function f(*Gauge) to each gauge in a set
+func (m *Metrics) EachGauge(f func(g *Gauge)) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	gauges := make([]Gauge, len(m.gauges))
-
-	i := 0
-
 	for _, gauge := range m.gauges {
-		dgauge := *gauge
-		gauges[i] = dgauge
-		i++
+		f(gauge)
 	}
-
-	return gauges
 }
 
 // IntervalSnapshot returns recorded interval metrics snapshot

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -73,19 +73,19 @@ func TestMetricsCounters(t *testing.T) {
 	counters := m.Counters()
 
 	for _, counter := range counters {
-		if counter.Name == "test_counter" {
+		if counter.Name() == "test_counter" {
 			assert.Equal(t, int64(1), counter.Value())
-		} else if counter.Name == "test_counter_2" {
+		} else if counter.Name() == "test_counter_2" {
 			assert.Equal(t, int64(3), counter.Value())
 		} else {
-			t.Errorf("Unknown counter: %s", counter.Name)
+			t.Errorf("Unknown counter: %s", counter.Name())
 		}
 	}
 
 	m.Counter("test_counter").Inc()
 
 	for _, counter := range counters {
-		if counter.Name == "test_counter" {
+		if counter.Name() == "test_counter" {
 			assert.Equal(t, int64(1), counter.Value())
 		}
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -43,19 +43,19 @@ func TestMetricsGauges(t *testing.T) {
 	gauges := m.Gauges()
 
 	for _, gauge := range gauges {
-		if gauge.Name == "test_gauge" {
+		if gauge.Name() == "test_gauge" {
 			assert.Equal(t, int64(123), gauge.Value())
-		} else if gauge.Name == "test_gauge_2" {
+		} else if gauge.Name() == "test_gauge_2" {
 			assert.Equal(t, int64(321), gauge.Value())
 		} else {
-			t.Errorf("Unknown gauge: %s", gauge.Name)
+			t.Errorf("Unknown gauge: %s", gauge.Name())
 		}
 	}
 
 	m.Gauge("test_gauge").Set(231)
 
 	for _, gauge := range gauges {
-		if gauge.Name == "test_gauge" {
+		if gauge.Name() == "test_gauge" {
 			assert.Equal(t, int64(123), gauge.Value())
 		}
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -31,7 +31,7 @@ func TestMetricsSnapshot(t *testing.T) {
 	assert.Equal(t, int64(123), m.IntervalSnapshot()["test_gauge"])
 }
 
-func TestMetricsGauges(t *testing.T) {
+func TestMetrics_EachGauge(t *testing.T) {
 	m := NewMetrics(nil, 10)
 
 	m.RegisterGauge("test_gauge", "First")
@@ -40,9 +40,7 @@ func TestMetricsGauges(t *testing.T) {
 	m.Gauge("test_gauge").Set(123)
 	m.Gauge("test_gauge_2").Set(321)
 
-	gauges := m.Gauges()
-
-	for _, gauge := range gauges {
+	m.EachGauge(func(gauge *Gauge) {
 		if gauge.Name() == "test_gauge" {
 			assert.Equal(t, int64(123), gauge.Value())
 		} else if gauge.Name() == "test_gauge_2" {
@@ -50,18 +48,10 @@ func TestMetricsGauges(t *testing.T) {
 		} else {
 			t.Errorf("Unknown gauge: %s", gauge.Name())
 		}
-	}
-
-	m.Gauge("test_gauge").Set(231)
-
-	for _, gauge := range gauges {
-		if gauge.Name() == "test_gauge" {
-			assert.Equal(t, int64(123), gauge.Value())
-		}
-	}
+	})
 }
 
-func TestMetricsCounters(t *testing.T) {
+func TestMetrics_EachCounter(t *testing.T) {
 	m := NewMetrics(nil, 10)
 
 	m.RegisterCounter("test_counter", "First")
@@ -70,9 +60,7 @@ func TestMetricsCounters(t *testing.T) {
 	m.Counter("test_counter").Inc()
 	m.Counter("test_counter_2").Add(3)
 
-	counters := m.Counters()
-
-	for _, counter := range counters {
+	m.EachCounter(func(counter *Counter) {
 		if counter.Name() == "test_counter" {
 			assert.Equal(t, int64(1), counter.Value())
 		} else if counter.Name() == "test_counter_2" {
@@ -80,13 +68,5 @@ func TestMetricsCounters(t *testing.T) {
 		} else {
 			t.Errorf("Unknown counter: %s", counter.Name())
 		}
-	}
-
-	m.Counter("test_counter").Inc()
-
-	for _, counter := range counters {
-		if counter.Name() == "test_counter" {
-			assert.Equal(t, int64(1), counter.Value())
-		}
-	}
+	})
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -15,7 +15,7 @@ const (
 func (m *Metrics) Prometheus() string {
 	var buf strings.Builder
 
-	for _, counter := range m.Counters() {
+	m.EachCounter(func(counter *Counter) {
 		name := prometheusNamespace + `_` + counter.Name()
 
 		buf.WriteString(
@@ -23,9 +23,9 @@ func (m *Metrics) Prometheus() string {
 		)
 		buf.WriteString("# TYPE " + name + " counter\n")
 		buf.WriteString(name + " " + strconv.FormatInt(counter.Value(), 10) + "\n")
-	}
+	})
 
-	for _, gauge := range m.Gauges() {
+	m.EachGauge(func(gauge *Gauge) {
 		name := prometheusNamespace + `_` + gauge.Name()
 
 		buf.WriteString(
@@ -33,7 +33,7 @@ func (m *Metrics) Prometheus() string {
 		)
 		buf.WriteString("# TYPE " + name + " gauge\n")
 		buf.WriteString(name + " " + strconv.FormatInt(gauge.Value(), 10) + "\n")
-	}
+	})
 
 	return buf.String()
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -16,10 +16,10 @@ func (m *Metrics) Prometheus() string {
 	var buf strings.Builder
 
 	for _, counter := range m.Counters() {
-		name := prometheusNamespace + `_` + counter.Name
+		name := prometheusNamespace + `_` + counter.Name()
 
 		buf.WriteString(
-			"\n# HELP " + name + " " + counter.Desc + "\n",
+			"\n# HELP " + name + " " + counter.Desc() + "\n",
 		)
 		buf.WriteString("# TYPE " + name + " counter\n")
 		buf.WriteString(name + " " + strconv.FormatInt(counter.Value(), 10) + "\n")

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -26,10 +26,10 @@ func (m *Metrics) Prometheus() string {
 	}
 
 	for _, gauge := range m.Gauges() {
-		name := prometheusNamespace + `_` + gauge.Name
+		name := prometheusNamespace + `_` + gauge.Name()
 
 		buf.WriteString(
-			"\n# HELP " + name + " " + gauge.Desc + "\n",
+			"\n# HELP " + name + " " + gauge.Desc() + "\n",
 		)
 		buf.WriteString("# TYPE " + name + " gauge\n")
 		buf.WriteString(name + " " + strconv.FormatInt(gauge.Value(), 10) + "\n")


### PR DESCRIPTION
It's not necessary to copy the whole sets of metrics when we want to read them in a bunch atomically. The proposed changes reduce the amount if unnecessary object allocations a little bit. In addition, metrics name and description has been protected from modification. There was a chance that a name could be changed but it preserved in the metric map which led to inconsistency. 