### PR TITLE
Fix websocket close status to reflect the reason for the closure

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -155,7 +155,7 @@ func (n *Node) Shutdown() {
 			n.log.Infof("Closing active connections: %d", active)
 			// Close all registered sessions
 			for _, session := range n.hub.sessions {
-				session.Disconnect("Shutdown")
+				session.Disconnect("Shutdown", CloseGoingAway)
 			}
 
 			// Wait to make sure that disconnect queue is not empty
@@ -320,7 +320,7 @@ func transmit(s *Session, transmissions []string) {
 
 func (n *Node) handleCommandReply(s *Session, msg *Message, reply *CommandResult) {
 	if reply.Disconnect {
-		defer s.Disconnect("Command Failed")
+		defer s.Disconnect("Command Failed", CloseAbnormalClosure)
 	}
 
 	if reply.StopAllStreams {


### PR DESCRIPTION
According to [RFC6455](https://tools.ietf.org/html/rfc6455#section-7.4.2) it's not correct to use 3xxx close codes directly without registering in IANA. 

As far as I see ActionCable itself doesn't care too much about it. They have status code for abnormal status 
https://github.com/rails/rails/blob/61490805fe25091b080f5bba0e286716cdb56245/actioncable/lib/action_cable/connection/client_socket.rb#L42

And a success status (which i don't see to be used at all)

https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/connection/client_socket.rb#L91-L98

I've refactored this logic a little bit a tried to find an appropriate status code for each case AC terminates websocket connections.