### PR TITLE
Fix cli args help, align vars order

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -20,6 +20,10 @@ var (
 	fs          *flag.FlagSet
 )
 
+const (
+	deprecatedHost = "0.0.0.0|deprecated"
+)
+
 func init() {
 	// Configure namespaced flagSet with errorHandling set to ExitOnError (=1)
 	fs = flag.NewFlagSetWithEnvPrefix(os.Args[0], "ANYCABLE", 1)
@@ -44,7 +48,7 @@ func init() {
 	}
 
 	// Config vars
-	fs.StringVar(&defaults.Host, "host", "0.0.0.0", "")
+	fs.StringVar(&defaults.Host, "host", deprecatedHost, "")
 	fs.IntVar(&defaults.Port, "port", portDefault, "")
 	fs.StringVar(&defaults.Path, "path", "/cable", "")
 	fs.StringVar(&defaults.HealthPath, "health-path", "/health", "")
@@ -105,7 +109,7 @@ USAGE
   anycable-go [options]
 
 OPTIONS
-  --host                   Server host, default: 0.0.0.0, env: ANYCABLE_HOST
+  --host                   Server host, default: 0.0.0.0 (deprecated, will be changed to "localhost"), env: ANYCABLE_HOST
   --port                   Server port, default: 8080, env: ANYCABLE_PORT, PORT
   --path                   WebSocket endpoint path, default: /cable, env: ANYCABLE_PATH
   --health-path            HTTP health endpoint path, default: /health, env: ANYCABLE_HEALTH_PATH
@@ -143,17 +147,27 @@ func PrintHelp() {
 }
 
 func prepareComplexDefaults() {
-		defaults.Headers = parseHeaders(headers)
+	if defaults.Host == deprecatedHost {
+		fmt.Println(
+			`DEPRECATION WARNING: You're using default host configuration which starts AnyCable-Go
+server on all available interfaces including external ones. This is about to be changed
+to loopback interface only in future versions. Please, consider switching to "localhost"
+or set "0.0.0.0" explicitly in your configuration, if you want to continue with
+the current behavior and supress this message.`)
 
-		if debugMode {
-			defaults.LogLevel = "debug"
-			defaults.LogFormat = "text"
-		}
-
-		if defaults.MetricsPort == 0 {
-			defaults.MetricsPort = defaults.Port
-		}
+		defaults.Host = "0.0.0.0"
 	}
+	defaults.Headers = parseHeaders(headers)
+
+	if debugMode {
+		defaults.LogLevel = "debug"
+		defaults.LogFormat = "text"
+	}
+
+	if defaults.MetricsPort == 0 {
+		defaults.MetricsPort = defaults.Port
+	}
+}
 
 // parseHeaders returns a headers list with the values from
 // a comma-separated string list

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -74,29 +74,28 @@ func init() {
 	// CLI vars
 	fs.BoolVar(&showHelp, "h", false, "")
 	fs.BoolVar(&showVersion, "v", false, "")
+
+	fs.Parse(os.Args[1:])
 }
 
-// GetConfig returns CLI configuration
-func GetConfig() config.Config {
-	ensureParsed()
+// Config returns CLI configuration
+func Config() config.Config {
+	prepareComplexDefaults()
 	return defaults
 }
 
 // ShowVersion returns true if -v flag was provided
 func ShowVersion() bool {
-	ensureParsed()
 	return showVersion
 }
 
 // ShowHelp returns true if -h flag was provided
 func ShowHelp() bool {
-	ensureParsed()
 	return showHelp
 }
 
 // DebugMode returns true if -debug flag is provided
 func DebugMode() bool {
-	ensureParsed()
 	return debugMode
 }
 
@@ -143,9 +142,7 @@ func PrintHelp() {
 	fmt.Print(usage)
 }
 
-func ensureParsed() {
-	if !fs.Parsed() {
-		fs.Parse(os.Args[1:])
+func prepareComplexDefaults() {
 		defaults.Headers = parseHeaders(headers)
 
 		if debugMode {
@@ -157,7 +154,6 @@ func ensureParsed() {
 			defaults.MetricsPort = defaults.Port
 		}
 	}
-}
 
 // parseHeaders returns a headers list with the values from
 // a comma-separated string list

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -44,34 +44,36 @@ func init() {
 	}
 
 	// Config vars
-	fs.StringVar(&defaults.RPCHost, "rpc_host", "localhost:50051", "")
-	fs.StringVar(&defaults.RedisURL, "redis_url", redisDefault, "")
-	fs.StringVar(&defaults.RedisChannel, "redis_channel", "__anycable__", "")
 	fs.StringVar(&defaults.Host, "host", "0.0.0.0", "")
 	fs.IntVar(&defaults.Port, "port", portDefault, "")
 	fs.StringVar(&defaults.Path, "path", "/cable", "")
 	fs.StringVar(&defaults.HealthPath, "health-path", "/health", "")
-	fs.IntVar(&defaults.DisconnectRate, "disconnect_rate", 100, "")
-	fs.Int64Var(&defaults.MaxMessageSize, "max_message_size", 65536, "")
 
 	fs.StringVar(&defaults.SSL.CertPath, "ssl_cert", "", "")
 	fs.StringVar(&defaults.SSL.KeyPath, "ssl_key", "", "")
 
+	fs.StringVar(&defaults.RedisURL, "redis_url", redisDefault, "")
+	fs.StringVar(&defaults.RedisChannel, "redis_channel", "__anycable__", "")
+
+	fs.StringVar(&defaults.RPCHost, "rpc_host", "localhost:50051", "")
+	fs.StringVar(&headers, "headers", "cookie", "")
+	fs.IntVar(&defaults.DisconnectRate, "disconnect_rate", 100, "")
+	fs.Int64Var(&defaults.MaxMessageSize, "max_message_size", 65536, "")
+
 	fs.StringVar(&defaults.LogLevel, "log_level", "info", "")
 	fs.StringVar(&defaults.LogFormat, "log_format", "text", "")
+	fs.BoolVar(&debugMode, "debug", false, "")
 
 	fs.BoolVar(&defaults.MetricsLog, "metrics_log", false, "")
 	fs.IntVar(&defaults.MetricsLogInterval, "metrics_log_interval", 15, "")
 	fs.StringVar(&defaults.MetricsLogFormatter, "metrics_log_formatter", "", "")
+	fs.StringVar(&defaults.MetricsHTTP, "metrics_http", "", "")
 	fs.StringVar(&defaults.MetricsHost, "metrics_host", "", "")
 	fs.IntVar(&defaults.MetricsPort, "metrics_port", 0, "")
-	fs.StringVar(&defaults.MetricsHTTP, "metrics_http", "", "")
 
 	// CLI vars
-	fs.BoolVar(&showVersion, "v", false, "")
 	fs.BoolVar(&showHelp, "h", false, "")
-	fs.StringVar(&headers, "headers", "cookie", "")
-	fs.BoolVar(&debugMode, "debug", false, "")
+	fs.BoolVar(&showVersion, "v", false, "")
 }
 
 // GetConfig returns CLI configuration
@@ -104,7 +106,7 @@ USAGE
   anycable-go [options]
 
 OPTIONS
-  --host                   Server host, default: localhost, env: ANYCABLE_HOST
+  --host                   Server host, default: 0.0.0.0, env: ANYCABLE_HOST
   --port                   Server port, default: 8080, env: ANYCABLE_PORT, PORT
   --path                   WebSocket endpoint path, default: /cable, env: ANYCABLE_PATH
   --health-path            HTTP health endpoint path, default: /health, env: ANYCABLE_HEALTH_PATH

--- a/cmd/anycable-go/main.go
+++ b/cmd/anycable-go/main.go
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	config := cli.GetConfig()
+	config := cli.Config()
 
 	// init logging
 	err := utils.InitLogger(config.LogFormat, config.LogLevel)


### PR DESCRIPTION
- Add deprecation warning for default interface
- CLI args typo is fixed
- Order of CLI vars is aligned with docs for readability
