### PR TITLE
Use idiomatic constructions for synchronization, fix a potential deadlock

### DIFF
--- a/cmd/anycable-go/main.go
+++ b/cmd/anycable-go/main.go
@@ -124,12 +124,10 @@ func main() {
 
 	t := tebata.New(syscall.SIGINT, syscall.SIGTERM)
 
-	done := make(chan bool)
-
 	t.Reserve(func() {
 		ctx.Infof("Shutting down... (hit Ctrl-C to stop immediately)")
 		go func() {
-			termSig := make(chan os.Signal, 2)
+			termSig := make(chan os.Signal, 1)
 			signal.Notify(termSig, syscall.SIGINT, syscall.SIGTERM)
 			<-termSig
 			ctx.Warnf("Immediate termination requested. Stopped")
@@ -166,7 +164,7 @@ func main() {
 	t.Reserve(os.Exit, 0)
 
 	// Hang forever unless Exit is called
-	<-done
+	select {}
 }
 
 func buildServer(node *node.Node, host string, port string, ssl *config.SSLOptions) *server.HTTPServer {

--- a/node/disconnect_queue.go
+++ b/node/disconnect_queue.go
@@ -44,7 +44,7 @@ func NewDisconnectQueue(node *Node, rate int) *DisconnectQueue {
 		disconnect: make(chan *Session, 4096),
 		rate:       rateDuration,
 		log:        ctx,
-		shutdown:   make(chan struct{}),
+		shutdown:   make(chan struct{}, 1),
 	}
 }
 
@@ -68,6 +68,7 @@ func (d *DisconnectQueue) Run() {
 func (d *DisconnectQueue) Shutdown() error {
 	d.mu.Lock()
 	if d.isStopped {
+		d.mu.Unlock()
 		return nil
 	}
 
@@ -76,7 +77,6 @@ func (d *DisconnectQueue) Shutdown() error {
 	d.mu.Unlock()
 
 	left := len(d.disconnect)
-	defer close(d.disconnect)
 
 	if left == 0 {
 		return nil

--- a/node/disconnect_queue_test.go
+++ b/node/disconnect_queue_test.go
@@ -1,41 +1,76 @@
 package node
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDisconnectQueueShutdown(t *testing.T) {
+func TestDisconnectQueue_Run(t *testing.T) {
+	t.Run("Disconnects sessions", func(t *testing.T) {
+		q := newQueue()
+		defer q.Shutdown()
+
+		q.Enqueue(NewMockSession("1"))
+		assert.Equal(t, 1, q.Size())
+
+		go func() {
+			q.Run()
+		}()
+
+		// TODO: We need a trully node mock to control disconnect operation
+		for q.Size() > 0 {
+			runtime.Gosched()
+		}
+	})
+}
+
+func TestDisconnectQueue_Shutdown(t *testing.T) {
+	t.Run("Disconnects sessions", func(t *testing.T) {
+		q := newQueue()
+
+		q.Enqueue(NewMockSession("1"))
+		q.Enqueue(NewMockSession("2"))
+		assert.Equal(t, 2, q.Size())
+
+		q.Shutdown()
+		assert.Equal(t, 0, q.Size())
+	})
+
+	t.Run("Stops after timeout", func(t *testing.T) {
+		t.Skip("TODO: We need a trully node mock to control disconnect operation")
+	})
+
+	t.Run("Allows multiple entering", func(t *testing.T) {
+		q := newQueue()
+
+		for i := 1; i <= 10; i++ {
+			q.Shutdown()
+		}
+	})
+}
+
+func TestDisconnectQueue_Enqueue(t *testing.T) {
+	t.Run("Adds sessions to the queue", func(t *testing.T) {
+		q := newQueue()
+
+		q.Enqueue(NewMockSession("1"))
+		assert.Equal(t, 1, q.Size())
+	})
+
+	t.Run("After shutdown", func(t *testing.T) {
+		q := newQueue()
+		q.Shutdown()
+
+		q.Enqueue(NewMockSession("1"))
+		assert.Equal(t, 0, q.Size())
+	})
+}
+
+func newQueue() *DisconnectQueue {
 	node := NewMockNode()
+	q := NewDisconnectQueue(&node, 1)
 
-	session := NewMockSession("1")
-	session2 := NewMockSession("2")
-
-	dq := NewDisconnectQueue(&node, 1)
-
-	dq.Enqueue(session)
-	assert.Equal(t, 1, dq.Size(), "Disconnect queue size should be equal to 1")
-
-	go func() {
-		<-dq.shutdown
-	}()
-
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-
-	dq.Shutdown()
-
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-	go dq.Enqueue(session2)
-
-	assert.Equal(t, 0, dq.Size(), "Disconnect queue size should be equal to 0")
+	return q
 }

--- a/node/disconnect_queue_test.go
+++ b/node/disconnect_queue_test.go
@@ -18,7 +18,7 @@ func TestDisconnectQueueShutdown(t *testing.T) {
 	assert.Equal(t, 1, dq.Size(), "Disconnect queue size should be equal to 1")
 
 	go func() {
-		<-dq.shutdownCh
+		<-dq.shutdown
 	}()
 
 	go dq.Enqueue(session2)

--- a/node/session_test.go
+++ b/node/session_test.go
@@ -1,43 +1,44 @@
 package node
 
 import (
+	"sync"
 	"testing"
 )
 
 func TestSendRaceConditions(t *testing.T) {
-	done := make(chan bool)
+	var wg sync.WaitGroup
 
 	for i := 1; i <= 10; i++ {
 		session := NewMockSession("123")
 		// small buffer channel
 		session.send = make(chan []byte, 1)
 
+		wg.Add(2)
 		go func() {
 			go func() {
 				session.Send([]byte("hi!"))
-				done <- true
+				wg.Done()
 			}()
 
 			go func() {
 				session.Send([]byte("bye"))
-				done <- true
+				wg.Done()
 			}()
 		}()
 
+		wg.Add(2)
 		go func() {
 			go func() {
 				session.Send([]byte("bye"))
-				done <- true
+				wg.Done()
 			}()
 
 			go func() {
 				session.Send([]byte("why"))
-				done <- true
+				wg.Done()
 			}()
 		}()
 	}
 
-	for i := 1; i <= 40; i++ {
-		<-done
-	}
+	wg.Wait()
 }


### PR DESCRIPTION
Looking through the code I've found a couple of places where some more specific technics for synchronization makes more sense. In addition, I've fixed a potential deadlock on multiple `DisconnectQueue#Shutdown` invocations and add more tests.