### PR TITLE
Configurable max message size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Configure maximum message size via `--max_message_size`. Defaults to 65536 (64kb).
+
 ## 0.6.1 (2018-12-21) "X-mas time is here again!" 🎅
 
 - Add HTTP health check endpoint. ([@sponomarev][])

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -52,6 +52,7 @@ func init() {
 	fs.StringVar(&defaults.Path, "path", "/cable", "")
 	fs.StringVar(&defaults.HealthPath, "health-path", "/health", "")
 	fs.IntVar(&defaults.DisconnectRate, "disconnect_rate", 100, "")
+	fs.Int64Var(&defaults.MaxMessageSize, "max_message_size", 65536, "")
 
 	fs.StringVar(&defaults.SSL.CertPath, "ssl_cert", "", "")
 	fs.StringVar(&defaults.SSL.KeyPath, "ssl_key", "", "")
@@ -117,6 +118,7 @@ OPTIONS
   --rpc_host               RPC service address, default: localhost:50051, env: ANYCABLE_RPC_HOST
   --headers                List of headers to proxy to RPC, default: cookie, env: ANYCABLE_HEADERS
   --disconnect_rate        Max number of Disconnect calls per second, default: 100, env: ANYCABLE_DISCONNECT_RATE
+  --max_message_size       Maximum size of a message in bytes, default: 65536, env: ANYCABLE_MAX_MESSAGE_SIZE
 
   --log_level              Set logging level (debug/info/warn/error/fatal), default: info, env: ANYCABLE_LOG_LEVEL
   --log_format             Set logging format (text, json), default: text, env: ANYCABLE_LOG_FORMAT

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	HealthPath          string
 	Headers             []string
 	SSL                 SSLOptions
+	MaxMessageSize      int64
 	DisconnectRate      int
 	LogLevel            string
 	LogFormat           string

--- a/node/session.go
+++ b/node/session.go
@@ -26,9 +26,8 @@ const (
 	// CloseGoingAway indicates ubnormal close
 	CloseGoingAway = websocket.CloseGoingAway
 
-	writeWait      = 10 * time.Second
-	maxMessageSize = 65536 // 64KB
-	pingInterval   = 3 * time.Second
+	writeWait    = 10 * time.Second
+	pingInterval = 3 * time.Second
 )
 
 var (
@@ -183,7 +182,7 @@ func (s *Session) Send(msg []byte) {
 
 // ReadMessages reads messages from ws connection and send them to node
 func (s *Session) ReadMessages() {
-	s.ws.SetReadLimit(maxMessageSize)
+	s.ws.SetReadLimit(s.node.Config.MaxMessageSize)
 
 	for {
 		_, message, err := s.ws.ReadMessage()


### PR DESCRIPTION
Fixes #30


### What is the purpose of this pull request? / What changes did you make? (overview)

Client message size is no longer hardcoded but can be set via command line option or env variable.