### PR TITLE
Use request id for session uids if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- Use request id for session uids if available. ([@sponomarev][])
+
+If a load balancer standing in front of WebSocket server assigns `X-Request-ID` header,
+this request ID will be used for session identification.
+
 ## 0.6.2 (2019-03-25)
 
 - Configure maximum message size via `--max_message_size`. Defaults to 65536 (64kb).
@@ -222,7 +227,7 @@ Do not add `identifier` field.
 
 - Refactor `Pinger`. ([@palkan][])
 
-`Pinger` now is always running and track the number of active connections by itself 
+`Pinger` now is always running and track the number of active connections by itself
 (no need to call `hub.Size()`).
 No more race conditions.
 

--- a/node/session.go
+++ b/node/session.go
@@ -10,7 +10,6 @@ import (
 	"github.com/anycable/anycable-go/utils"
 	"github.com/apex/log"
 	"github.com/gorilla/websocket"
-	nanoid "github.com/matoous/go-nanoid"
 )
 
 const (
@@ -86,10 +85,9 @@ func NewSession(node *Node, ws *websocket.Conn, request *http.Request) (*Session
 		connected:     false,
 	}
 
-	uid, err := nanoid.Nanoid()
-
+	uid, err := utils.FetchUID(request)
 	if err != nil {
-		defer session.Close("Nanoid Error", CloseInternalServerErr)
+		defer session.Close("UID Retrieval Error", CloseInternalServerErr)
 		return nil, err
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 
+	nanoid "github.com/matoous/go-nanoid"
 	"github.com/mattn/go-isatty"
 )
 
@@ -20,4 +21,14 @@ func FetchHeaders(r *http.Request, list []string) map[string]string {
 		res[header] = r.Header.Get(header)
 	}
 	return res
+}
+
+// FetchUID safely extracts uid from `X-Request-ID` header or generates a new one
+func FetchUID(r *http.Request) (string, error) {
+	requestID := r.Header.Get("X-Request-ID")
+	if requestID == "" {
+		return nanoid.Nanoid()
+	}
+
+	return requestID, nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchUID(t *testing.T) {
+	t.Run("Without request id", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		uid, _ := FetchUID(req)
+
+		assert.NotEqual(t, "", uid)
+	})
+
+	t.Run("With request id", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("x-request-id", "external-request-id")
+
+		uid, _ := FetchUID(req)
+
+		assert.Equal(t, "external-request-id", uid)
+	})
+}


### PR DESCRIPTION
If a load balancer standing in front of WebSocket server assigns `X-Request-ID` header,
this request ID will be used for session identification.

Heroku[ assigns ids to all requests](https://devcenter.heroku.com/articles/http-request-id).

For NGINX, this configuration is available for proxy-passed location:

```nginx
  location /cable {
      proxy_set_header X-Request-ID $request_id;
      proxy_pass http://anycable;
  }

```
