### PR TITLE
Set `REMOTE_ADDR` synthetic header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Set `REMOTE_ADDR` synthetic header ([@sponomarev][])
+
+It can be used on a RPC server side to access remote connection IP address.
+
 - Use request id for session uids if available. ([@sponomarev][])
 
 If a load balancer standing in front of WebSocket server assigns `X-Request-ID` header,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"net"
 	"net/http"
 	"os"
 
 	nanoid "github.com/matoous/go-nanoid"
 	"github.com/mattn/go-isatty"
 )
+
+const remoteAddrHeader = "REMOTE_ADDR"
 
 // IsTTY returns true if program is running with TTY
 func IsTTY() bool {
@@ -20,6 +23,7 @@ func FetchHeaders(r *http.Request, list []string) map[string]string {
 	for _, header := range list {
 		res[header] = r.Header.Get(header)
 	}
+	res[remoteAddrHeader], _, _ = net.SplitHostPort(r.RemoteAddr)
 	return res
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -34,16 +34,18 @@ func TestFetchHeaders(t *testing.T) {
 	t.Run("Without specified headers ", func(t *testing.T) {
 		headers := FetchHeaders(req, []string{})
 
-		assert.Len(t, headers, 0)
+		assert.Len(t, headers, 1)
+		assert.Equal(t, "192.0.2.1", headers["REMOTE_ADDR"])
 	})
 
 	t.Run("With specified headers ", func(t *testing.T) {
 		headers := FetchHeaders(req, []string{"cookies", "x-api-token"})
 
-		assert.Len(t, headers, 2)
+		assert.Len(t, headers, 3)
 
-		assert.Equal(t, "42", headers["x-api-token"])
-		assert.Equal(t, "yummy_cookie=raisin; tasty_cookie=strawberry", headers["cookies"])
 		assert.Empty(t, headers["accept-language"])
+		assert.Equal(t, req.Header.Get("x-api-token"), headers["x-api-token"])
+		assert.Equal(t, req.Header.Get("cookies"), headers["cookies"])
+		assert.Equal(t, "192.0.2.1", headers["REMOTE_ADDR"])
 	})
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -24,3 +24,26 @@ func TestFetchUID(t *testing.T) {
 		assert.Equal(t, "external-request-id", uid)
 	})
 }
+
+func TestFetchHeaders(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cookies", "yummy_cookie=raisin; tasty_cookie=strawberry")
+	req.Header.Set("X-Api-Token", "42")
+	req.Header.Set("Accept-Language", "ru")
+
+	t.Run("Without specified headers ", func(t *testing.T) {
+		headers := FetchHeaders(req, []string{})
+
+		assert.Len(t, headers, 0)
+	})
+
+	t.Run("With specified headers ", func(t *testing.T) {
+		headers := FetchHeaders(req, []string{"cookies", "x-api-token"})
+
+		assert.Len(t, headers, 2)
+
+		assert.Equal(t, "42", headers["x-api-token"])
+		assert.Equal(t, "yummy_cookie=raisin; tasty_cookie=strawberry", headers["cookies"])
+		assert.Empty(t, headers["accept-language"])
+	})
+}


### PR DESCRIPTION
This is the first step to support remote connection address available with AnyCable.

There were three options to where `REMOTE_ADDR` cab be included:
❌ To GRPC protocol itself - too huge change with backward incompatibility. I put this idea aside to potentially more significant protocol changes. I'm thinking about maybe replacing `headers` completely with more generic CGI variables aka Rack Env. They have some nice conventions and are supported widely in different languages to build http request object.
❌ To GRPC message  metadata – requires more code changes to the existent code, can't be presented in all grpc requests like `sid`
✅ Synthetic header – perfect temporary solution at the moment


Symmetric change in RPC server https://github.com/anycable/anycable/pull/88