### PR TITLE
Add gobench-cable binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ install-with-mruby:
 build:
 	go build -tags mrb -ldflags $(LD_FLAGS) -o $(OUTPUT) cmd/anycable-go/main.go
 
+build-gobench:
+	go build -tags mrb -ldflags $(LD_FLAGS) -o dist/gobench-cable cmd/gobench-cable/main.go
+
 prepare-mruby:
 	cd vendor/github.com/mitchellh/go-mruby && \
 	MRUBY_CONFIG=../../../../../../etc/build_config.rb make libmruby.a

--- a/cmd/gobench-cable/main.go
+++ b/cmd/gobench-cable/main.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/anycable/anycable-go/cli"
+	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/gobench"
+	"github.com/anycable/anycable-go/metrics"
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/server"
+	"github.com/anycable/anycable-go/utils"
+
+	log "github.com/apex/log"
+	"github.com/syossan27/tebata"
+)
+
+var (
+	version string
+)
+
+func init() {
+	if version == "" {
+		version = "0.1.0-unknown"
+	}
+}
+
+func main() {
+	if cli.ShowVersion() {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	if cli.ShowHelp() {
+		cli.PrintHelp()
+		os.Exit(0)
+	}
+
+	config := cli.Config()
+
+	// init logging
+	err := utils.InitLogger(config.LogFormat, config.LogLevel)
+
+	if err != nil {
+		log.Errorf("!!! Failed to initialize logger !!!\n%v", err)
+		os.Exit(1)
+	}
+
+	ctx := log.WithFields(log.Fields{"context": "main"})
+
+	if cli.DebugMode() {
+		ctx.Debug("🔧 🔧 🔧 Debug mode is on 🔧 🔧 🔧")
+	}
+
+	ctx.Infof("Starting GoBenchCable %s (pid: %d)", version, os.Getpid())
+
+	var metricsPrinter metrics.Printer
+
+	if config.MetricsLogEnabled() {
+		if config.MetricsLogFormatterEnabled() {
+			customPrinter, err := metrics.NewCustomPrinter(config.MetricsLogFormatter)
+
+			if err == nil {
+				metricsPrinter = customPrinter
+			} else {
+				log.Errorf("!!! Failed to initialize custom log printer !!!\n%v", err)
+				os.Exit(1)
+			}
+		} else {
+			metricsPrinter = metrics.NewBasePrinter()
+		}
+	}
+
+	metrics := metrics.NewMetrics(metricsPrinter, config.MetricsLogInterval)
+
+	controller := gobench.NewController(&config, metrics)
+
+	node := node.NewNode(&config, controller, metrics)
+
+	go func() {
+		if err := controller.Start(); err != nil {
+			ctx.Errorf("!!! Controller failed !!!\n%v", err)
+			os.Exit(1)
+		}
+	}()
+
+	wsServer := buildServer(node, config.Host, strconv.Itoa(config.Port), &config.SSL)
+	wsServer.Mux.Handle(config.Path, http.HandlerFunc(wsServer.WebsocketHandler))
+	ctx.Infof("Handle WebSocket connections at %s", config.Path)
+
+	wsServer.Mux.Handle(config.HealthPath, http.HandlerFunc(wsServer.HealthHandler))
+	ctx.Infof("Handle health connections at %s", config.HealthPath)
+
+	go runServer(wsServer)
+
+	go metrics.Run()
+
+	t := tebata.New(syscall.SIGINT, syscall.SIGTERM)
+
+	t.Reserve(func() {
+		ctx.Infof("Shutting down... (hit Ctrl-C to stop immediately)")
+		go func() {
+			termSig := make(chan os.Signal, 1)
+			signal.Notify(termSig, syscall.SIGINT, syscall.SIGTERM)
+			<-termSig
+			ctx.Warnf("Immediate termination requested. Stopped")
+			os.Exit(0)
+		}()
+	})
+	t.Reserve(metrics.Shutdown)
+	t.Reserve(wsServer.Stop)
+	t.Reserve(node.Shutdown)
+
+	if config.MetricsHTTPEnabled() {
+		metricsServer := wsServer
+
+		if config.MetricsPort != config.Port {
+			port := strconv.Itoa(config.MetricsPort)
+			host := config.Host
+			if config.MetricsHost != "" {
+				host = config.MetricsHost
+			}
+			metricsServer = buildServer(node, host, port, &config.SSL)
+			ctx.Infof("Serve metrics at %s:%s%s", config.Host, port, config.MetricsHTTP)
+		} else {
+			ctx.Infof("Serve metrics at %s", config.MetricsHTTP)
+		}
+
+		metricsServer.Mux.Handle(config.MetricsHTTP, http.HandlerFunc(metrics.PrometheusHandler))
+
+		if metricsServer != wsServer {
+			go runServer(metricsServer)
+			t.Reserve(metricsServer.Stop)
+		}
+	}
+
+	t.Reserve(os.Exit, 0)
+
+	// Hang forever unless Exit is called
+	select {}
+}
+
+func buildServer(node *node.Node, host string, port string, ssl *config.SSLOptions) *server.HTTPServer {
+	s, err := server.NewServer(node, host, port, ssl)
+
+	if err != nil {
+		fmt.Printf("!!! Failed to initialize HTTP server at %s:%s !!!\n%v", err, host, port)
+		os.Exit(1)
+	}
+
+	return s
+}
+
+func runServer(s *server.HTTPServer) {
+	if err := s.Start(); err != nil {
+		if !s.Stopped() {
+			log.Errorf("HTTP server at %s stopped: %v", err, s.Address())
+			os.Exit(1)
+		}
+	}
+}

--- a/gobench/gobench.go
+++ b/gobench/gobench.go
@@ -1,0 +1,169 @@
+// Package gobench implements alternative controller for benchmarking Go server w/o RPC.
+// Mimics BenchmarkChannel from https://github.com/palkan/websocket-shootout/blob/master/ruby/action-cable-server/app/channels/benchmark_channel.rb
+package gobench
+
+import (
+	"encoding/json"
+
+	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/metrics"
+	"github.com/anycable/anycable-go/node"
+	"github.com/apex/log"
+
+	nanoid "github.com/matoous/go-nanoid"
+)
+
+const (
+	metricsCalls = "gochannels_call_total"
+
+	identifier = "\"{\\\"channel\\\":\\\"BenchmarkChannel\\\"}\""
+
+	welcomeMessage      = "{\"type\":\"welcome\"}"
+	confirmationMessage = "{\"type\":\"confirm_subscription\",\"identifier\":\"{\\\"channel\\\":\\\"BenchmarkChannel\\\"}\"}"
+)
+
+// Identifiers represents a connection identifiers
+type Identifiers struct {
+	ID string `json:"id"`
+}
+
+// BroadcastMessage represents a pubsub payload
+type BroadcastMessage struct {
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+}
+
+// Controller implements node.Controller interface for gRPC
+type Controller struct {
+	metrics *metrics.Metrics
+	log     *log.Entry
+}
+
+// NewController builds new Controller from config
+func NewController(config *config.Config, metrics *metrics.Metrics) *Controller {
+	metrics.RegisterCounter(metricsCalls, "The total number of Go channels calls")
+
+	return &Controller{log: log.WithField("context", "gobench"), metrics: metrics}
+}
+
+// Start is no-op
+func (c *Controller) Start() error {
+	return nil
+}
+
+// Shutdown is no-op
+func (c *Controller) Shutdown() error {
+	return nil
+}
+
+// Authenticate allows everyone to connect and returns welcome message and rendom ID as identifier
+func (c *Controller) Authenticate(sid string, path string, headers *map[string]string) (string, []string, error) {
+	c.metrics.Counter(metricsCalls).Inc()
+
+	id, err := nanoid.Nanoid()
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	identifiers := Identifiers{ID: id}
+	idstr, err := json.Marshal(&identifiers)
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	return string(idstr), []string{welcomeMessage}, nil
+}
+
+// Subscribe performs Command RPC call with "subscribe" command
+func (c *Controller) Subscribe(sid string, id string, channel string) (*node.CommandResult, error) {
+	c.metrics.Counter(metricsCalls).Inc()
+	res := &node.CommandResult{
+		Disconnect:     false,
+		StopAllStreams: false,
+		Streams:        []string{"all"},
+		Transmissions:  []string{confirmationMessage},
+	}
+	return res, nil
+}
+
+// Unsubscribe performs Command RPC call with "unsubscribe" command
+func (c *Controller) Unsubscribe(sid string, id string, channel string) (*node.CommandResult, error) {
+	c.metrics.Counter(metricsCalls).Inc()
+	res := &node.CommandResult{
+		Disconnect:     false,
+		StopAllStreams: true,
+		Streams:        nil,
+		Transmissions:  nil,
+	}
+	return res, nil
+}
+
+// Perform performs Command RPC call with "perform" command
+func (c *Controller) Perform(sid string, id string, channel string, data string) (res *node.CommandResult, err error) {
+	c.metrics.Counter(metricsCalls).Inc()
+
+	var payload map[string]interface{}
+
+	if err = json.Unmarshal([]byte(data), &payload); err != nil {
+		return nil, err
+	}
+
+	switch action := payload["action"].(string); action {
+	case "echo":
+		res = &node.CommandResult{
+			Disconnect:     false,
+			StopAllStreams: false,
+			Streams:        nil,
+			Transmissions:  []string{string(data)},
+		}
+	case "broadcast":
+		broadcastMsg, err := json.Marshal(&payload)
+
+		if err != nil {
+			return nil, err
+		}
+
+		broadcast := node.StreamMessage{
+			Stream: "all",
+			Data:   string(broadcastMsg),
+		}
+
+		payload["action"] = "broadcastResult"
+
+		response, err := json.Marshal(
+			map[string]interface{}{
+				"message":    payload,
+				"identifier": identifier,
+			},
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		res = &node.CommandResult{
+			Disconnect:     false,
+			StopAllStreams: false,
+			Streams:        nil,
+			Transmissions:  []string{string(response)},
+			Broadcasts:     []*node.StreamMessage{&broadcast},
+		}
+	default:
+		res = &node.CommandResult{
+			Disconnect:     false,
+			StopAllStreams: false,
+			Streams:        nil,
+			Transmissions:  nil,
+		}
+	}
+
+	return res, nil
+}
+
+// Disconnect performs disconnect RPC call
+func (c *Controller) Disconnect(sid string, id string, subscriptions []string, path string, headers *map[string]string) error {
+	c.metrics.Counter(metricsCalls).Inc()
+	return nil
+}


### PR DESCRIPTION
Pure Go implementation (w/o RPC) of [BenchmarkChannel](https://github.com/palkan/websocket-shootout/blob/master/ruby/action-cable-server/app/channels/benchmark_channel.rb) solely for benchmarking Go server functionality.
