### PR TITLE
Replace pool with single gRPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.0.0-dev
 
+- Use single gRPC client instance instead of a pool. ([@palkan][])
+
+gRPC connection provides concurrency via H2 streams (with load balancing). Using a pool doesn't bring any performance
+improvements and sometimes 'cause unstability (e.g., ResourcesExhausted or Unavailable exceptions under the load).
+
+We still limit the number of concurrent RPC requests. Now you can configure it via `--rpc_concurrency` setting.
+
+See [PR#88](https://github.com/anycable/anycable-go/pull/88) for more.
+
 - Add `--disconnect_timeout` option to specify the timeout for graceful shutdown of the disconnect queue. ([@palkan][])
 
 - Add `mem_sys_bytes` metric. ([@palkan][])

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -56,6 +56,7 @@ func init() {
 	fs.StringVar(&defaults.RedisChannel, "redis_channel", "__anycable__", "")
 
 	fs.StringVar(&defaults.RPC.Host, "rpc_host", "localhost:50051", "")
+	fs.IntVar(&defaults.RPC.Concurrency, "rpc_concurrency", 28, "")
 	fs.StringVar(&headers, "headers", "cookie", "")
 
 	fs.IntVar(&defaults.WS.ReadBufferSize, "read_buffer_size", 1024, "")
@@ -123,6 +124,7 @@ OPTIONS
   --redis_channel            Redis channel for broadcasts, default: __anycable__, env: ANYCABLE_REDIS_CHANNEL
 
   --rpc_host                 RPC service address, default: localhost:50051, env: ANYCABLE_RPC_HOST
+  --rpc_concurrency          Max number of concurrent RPC request; should be slightly less than the RPC server concurrency, default: 28, env: ANYCABLE_RPC_CONCURRENCY
   --headers                  List of headers to proxy to RPC, default: cookie, env: ANYCABLE_HEADERS
 
   --disconnect_rate          Max number of Disconnect calls per second, default: 100, env: ANYCABLE_DISCONNECT_RATE

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -2,10 +2,15 @@ package rpc
 
 // Config contains RPC controller configuration
 type Config struct {
+	// RPC instance host
 	Host string
+	// The max number of simulteneous requests.
+	// Should be slightly less than the RPC server concurrency to avoid
+	// ResourceExhausted errors
+	Concurrency int
 }
 
 // NewConfig builds a new config
 func NewConfig() Config {
-	return Config{}
+	return Config{Concurrency: 28}
 }


### PR DESCRIPTION
Improve gRPC performance and stability by getting rid of the connections pool in favor of the built-in streaming and multiplexing provided by the grpc package.

[Benchmarks](https://github.com/anycable/anycable-go/blob/master/cmd/rpcbench/main.go) show that using a single client result in less errors and slightly better performance than using a pool.

Also, retry mechanism has been also improved to handle exhausted and unavailable errors differently: when we receive ResourceExhausted we try to re-run the request almost immediately. The reason is that we assume that the concurrency settings for the client and the server are similar (though not equal, see below), thus, there could not be real exhaustion but the lag in server implementation (it looks like the worker is returned to the pool after the request completed, so there is a little gap).

For the same reason we set (and recommend setting) the default concurrency for RPC client to be a slightly less than the number of workers in the server (the corresponding defaults are 28 < 30).