### PR TITLE
docker: change alpine version to latest

### DIFF
--- a/.docker/Dockerfile.alpine-linux-amd64
+++ b/.docker/Dockerfile.alpine-linux-amd64
@@ -1,5 +1,5 @@
 # https://blog.codeship.com/building-minimal-docker-containers-for-go-applications
-FROM alpine:edge
+FROM alpine:latest
 
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 ADD .docker/passwd.nobody /etc/passwd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Change alpine version from edge to latest ([@ericmatte][])
+
 ## 0.6.4 (2019-09-16)
 
 - Add ENV support to mruby scripts. ([@dmcrorieGIT][])


### PR DESCRIPTION
Fixes https://github.com/anycable/anycable-go/issues/92

### What is the purpose of this pull request?

The purpose of this pull request is to not use the `edge` version of alpine; as it is not [suitable for production environment](https://wiki.alpinelinux.org/wiki/Edge).

### Please ensure your PR is ready:
#### Add Changelog entry
✅ Done. Let me know if it should be any different.
