### PR TITLE
Add remote commands support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 1.0.0-dev
 
-- Added HTTP broadcasting adapter. ([@palkan][])
+- Add support for remote commands. ([@palkan][])
 
-- Added Redis Sentinel support. ([@rolandg][])
+Handle remote commands sent via Pub/Sub. Currently, only remote disconnect is supported.
+
+- Add HTTP broadcasting adapter. ([@palkan][])
+
+- Add Redis Sentinel support. ([@rolandg][])
 
 - Send `disconnect` messages on server restart and authentication failures. ([@palkan][])
 

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,20 @@ build-protos:
 test:
 	go test -tags mrb ./...
 
-test-conformance:
+tmp/anycable-go-test:
 	go build -tags mrb -o tmp/anycable-go-test cmd/anycable-go/main.go
+
+test-conformance: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable"
+
+test-conformance-ssl: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token --ssl_key=etc/ssl/server.key --ssl_cert=etc/ssl/server.crt --port=8443" --target-url="wss://localhost:8443/cable"
+
+test-conformance-http: tmp/anycable-go-test
+	go build -tags mrb -o tmp/anycable-go-test cmd/anycable-go/main.go
 	BUNDLE_GEMFILE=.circleci/Gemfile ANYCABLE_BROADCAST_ADAPTER=http ANYCABLE_HTTP_BROADCAST_SECRET=any_secret bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable"
+
+test-conformance-all: test-conformance test-conformance-ssl test-conformance-http
 
 test-ci: prepare prepare-mruby test test-conformance
 
@@ -100,3 +109,5 @@ vet:
 
 fmt:
 	go fmt ./...
+
+.PHONY: tmp/anycable-go-test

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -18,3 +18,27 @@ func TestSessionStateMergeConnectionState(t *testing.T) {
 		assert.Equal(t, "super new", (*env.ConnectionState)["b"])
 	})
 }
+
+func TestPubSubMessageFromJSON(t *testing.T) {
+	t.Run("Remote disconnect message", func(t *testing.T) {
+		msg := []byte("{\"command\":\"disconnect\",\"payload\":{\"identifier\":\"14\",\"reconnect\":false}}")
+
+		result, err := PubSubMessageFromJSON(msg)
+		assert.Nil(t, err)
+
+		casted := result.(RemoteDisconnectMessage)
+		assert.Equal(t, "14", casted.Identifier)
+		assert.Equal(t, false, casted.Reconnect)
+	})
+
+	t.Run("Broadcast message", func(t *testing.T) {
+		msg := []byte("{\"stream\":\"bread-test\",\"data\":\"test\"}")
+
+		result, err := PubSubMessageFromJSON(msg)
+		assert.Nil(t, err)
+
+		casted := result.(StreamMessage)
+		assert.Equal(t, "bread-test", casted.Stream)
+		assert.Equal(t, "test", casted.Data)
+	})
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

Handle remote commands sent via Pub/Sub. Currently, only remote disconnect is supported.

### What changes did you make? (overview)

- [x] Refactored `node.HandlePubSub` to support different payload types
- [x] Added `hub.disconnectSessions` 
### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation

