### PR TITLE
Add AnyCable-Go version banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-dev
 
+- Added AnyCable-Go version banner. ([@sponomarev][]
+
 - Added Redis Sentinel support. ([@rolandg][])
 
 - Send `disconnect` messages on server restart and authentication failures. ([@palkan][])

--- a/server/ws_handler.go
+++ b/server/ws_handler.go
@@ -35,6 +35,8 @@ func WebsocketHandler(app *node.Node, fetchHeaders []string, config *WSConfig) h
 			EnableCompression: config.EnableCompression,
 		}
 
+		w.Header().Set("x-anycable-version", utils.Version())
+
 		ws, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			ctx.Debugf("Websocket connection upgrade error: %#v", err.Error())


### PR DESCRIPTION
The banner is shown in `X-Anycable-Version` header.

