### PR TITLE
Abstract message encoding functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifdef VERSION
 else
 	COMMIT := $(shell sh -c 'git log --pretty=format:"%h" -n 1 ')
 	VERSION := $(shell sh -c 'git tag -l --sort=-version:refname "v*" | head -n1')
-	LD_FLAGS="-s -w -X github.com/anycable/anycable-go/utils.sha=$(COMMIT) -X github.com/anycable/anycable-go/utils.version="
+	LD_FLAGS="-s -w -X github.com/anycable/anycable-go/utils.sha=$(COMMIT) -X github.com/anycable/anycable-go/utils.version=$(VERSION)"
 endif
 
 GOBUILD=go build -ldflags $(LD_FLAGS) -a

--- a/comm/json_encoder.go
+++ b/comm/json_encoder.go
@@ -1,0 +1,43 @@
+package comm
+
+import (
+	"encoding/json"
+	"github.com/anycable/anycable-go/common"
+)
+
+type jsonEncoder struct {
+}
+
+func (jp jsonEncoder) Unmarshal(data []byte, v interface{}) error{
+	return json.Unmarshal(data, &v)
+}
+
+func (jp jsonEncoder) MarshalReply(v interface{}) ([]byte, error){
+	return json.Marshal(&v)
+}
+
+func (jp jsonEncoder) MarshalPing(v interface{}) ([]byte, error){
+	return json.Marshal(&v)
+}
+
+func (jp jsonEncoder) MarshalDisconnect(v interface{}) ([]byte, error){
+	return json.Marshal(&v)
+}
+
+func (jp jsonEncoder) MarshalTransmissions(transmissions []string, msg *common.Message) ([][]byte, error){
+	var transmissionBytes [][]byte
+	for _, transmission := range transmissions{
+		transmissionBytes = append(transmissionBytes, []byte(transmission))
+	}
+
+	return transmissionBytes, nil
+}
+
+func (jp jsonEncoder) MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error){
+	var transmissionBytes [][]byte
+	for _, transmission := range transmissions{
+		transmissionBytes = append(transmissionBytes, []byte(transmission))
+	}
+
+	return transmissionBytes, nil
+}

--- a/comm/json_encoder.go
+++ b/comm/json_encoder.go
@@ -3,7 +3,6 @@ package comm
 import (
 	"encoding/json"
 	"github.com/anycable/anycable-go/common"
-	"github.com/anycable/anycable-go/node"
 )
 
 type jsonEncoder struct {
@@ -13,15 +12,15 @@ func (jp jsonEncoder) Unmarshal(data []byte, v interface{}) error{
 	return json.Unmarshal(data, &v)
 }
 
-func (jp jsonEncoder) MarshalReply(message *node.Reply) ([]byte, error){
+func (jp jsonEncoder) MarshalReply(message *common.Reply) ([]byte, error){
 	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalPing(message *node.PingMessage) ([]byte, error){
+func (jp jsonEncoder) MarshalPing(message *common.PingMessage) ([]byte, error){
 	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalDisconnect(message *node.DisconnectMessage) ([]byte, error){
+func (jp jsonEncoder) MarshalDisconnect(message *common.DisconnectMessage) ([]byte, error){
 	return json.Marshal(&message)
 }
 

--- a/comm/json_encoder.go
+++ b/comm/json_encoder.go
@@ -3,6 +3,7 @@ package comm
 import (
 	"encoding/json"
 	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/node"
 )
 
 type jsonEncoder struct {
@@ -12,19 +13,19 @@ func (jp jsonEncoder) Unmarshal(data []byte, v interface{}) error{
 	return json.Unmarshal(data, &v)
 }
 
-func (jp jsonEncoder) MarshalReply(v interface{}) ([]byte, error){
-	return json.Marshal(&v)
+func (jp jsonEncoder) MarshalReply(message *node.Reply) ([]byte, error){
+	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalPing(v interface{}) ([]byte, error){
-	return json.Marshal(&v)
+func (jp jsonEncoder) MarshalPing(message *node.PingMessage) ([]byte, error){
+	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalDisconnect(v interface{}) ([]byte, error){
-	return json.Marshal(&v)
+func (jp jsonEncoder) MarshalDisconnect(message *node.DisconnectMessage) ([]byte, error){
+	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalTransmissions(transmissions []string, msg *common.Message) ([][]byte, error){
+func (jp jsonEncoder) MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error){
 	var transmissionBytes [][]byte
 	for _, transmission := range transmissions{
 		transmissionBytes = append(transmissionBytes, []byte(transmission))

--- a/comm/json_encoder.go
+++ b/comm/json_encoder.go
@@ -8,34 +8,38 @@ import (
 type jsonEncoder struct {
 }
 
-func (jp jsonEncoder) Unmarshal(data []byte, v interface{}) error{
+func (jp jsonEncoder) Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, &v)
 }
 
-func (jp jsonEncoder) MarshalReply(message *common.Reply) ([]byte, error){
+func (jp jsonEncoder) MarshalIsBinary() bool {
+	return false
+}
+
+func (jp jsonEncoder) MarshalReply(message *common.Reply) ([]byte, error) {
 	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalPing(message *common.PingMessage) ([]byte, error){
+func (jp jsonEncoder) MarshalPing(message *common.PingMessage) ([]byte, error) {
 	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalDisconnect(message *common.DisconnectMessage) ([]byte, error){
+func (jp jsonEncoder) MarshalDisconnect(message *common.DisconnectMessage) ([]byte, error) {
 	return json.Marshal(&message)
 }
 
-func (jp jsonEncoder) MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error){
+func (jp jsonEncoder) MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error) {
 	var transmissionBytes [][]byte
-	for _, transmission := range transmissions{
+	for _, transmission := range transmissions {
 		transmissionBytes = append(transmissionBytes, []byte(transmission))
 	}
 
 	return transmissionBytes, nil
 }
 
-func (jp jsonEncoder) MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error){
+func (jp jsonEncoder) MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error) {
 	var transmissionBytes [][]byte
-	for _, transmission := range transmissions{
+	for _, transmission := range transmissions {
 		transmissionBytes = append(transmissionBytes, []byte(transmission))
 	}
 

--- a/comm/json_encoder.go
+++ b/comm/json_encoder.go
@@ -29,15 +29,14 @@ func (jp jsonEncoder) MarshalDisconnect(message *common.DisconnectMessage) ([]by
 }
 
 func (jp jsonEncoder) MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error) {
-	var transmissionBytes [][]byte
-	for _, transmission := range transmissions {
-		transmissionBytes = append(transmissionBytes, []byte(transmission))
-	}
-
-	return transmissionBytes, nil
+	return marshalTransmissions(transmissions)
 }
 
 func (jp jsonEncoder) MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error) {
+	return marshalTransmissions(transmissions)
+}
+
+func marshalTransmissions(transmissions []string) ([][]byte, error) {
 	var transmissionBytes [][]byte
 	for _, transmission := range transmissions {
 		transmissionBytes = append(transmissionBytes, []byte(transmission))

--- a/comm/json_encoder.go
+++ b/comm/json_encoder.go
@@ -8,8 +8,8 @@ import (
 type jsonEncoder struct {
 }
 
-func (jp jsonEncoder) Unmarshal(data []byte, v interface{}) error {
-	return json.Unmarshal(data, &v)
+func (jp jsonEncoder) Unmarshal(data []byte, message **common.Message) error {
+	return json.Unmarshal(data, message)
 }
 
 func (jp jsonEncoder) MarshalIsBinary() bool {

--- a/comm/message_encoder.go
+++ b/comm/message_encoder.go
@@ -2,13 +2,14 @@ package comm
 
 import (
 	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/node"
 )
 
 type MessageEncoder interface {
-	MarshalReply(v interface{}) ([]byte, error)
-	MarshalPing(v interface{}) ([]byte, error)
-	MarshalDisconnect(v interface{}) ([]byte, error)
-	MarshalTransmissions(transmissions []string, msg *common.Message) ([][]byte, error)
+	MarshalReply(message *node.Reply) ([]byte, error)
+	MarshalPing(message *node.PingMessage) ([]byte, error)
+	MarshalDisconnect(message *node.DisconnectMessage) ([]byte, error)
+	MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error)
 	MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error)
 	Unmarshal(data []byte, v interface{}) error
 }

--- a/comm/message_encoder.go
+++ b/comm/message_encoder.go
@@ -5,7 +5,7 @@ import (
 )
 
 type MessageEncoder interface {
-	Unmarshal(data []byte, v interface{}) error
+	Unmarshal(data []byte, message **common.Message) error
 	MarshalIsBinary() bool
 	MarshalReply(message *common.Reply) ([]byte, error)
 	MarshalPing(message *common.PingMessage) ([]byte, error)

--- a/comm/message_encoder.go
+++ b/comm/message_encoder.go
@@ -6,6 +6,7 @@ import (
 
 type MessageEncoder interface {
 	Unmarshal(data []byte, v interface{}) error
+	MarshalIsBinary() bool
 	MarshalReply(message *common.Reply) ([]byte, error)
 	MarshalPing(message *common.PingMessage) ([]byte, error)
 	MarshalDisconnect(message *common.DisconnectMessage) ([]byte, error)

--- a/comm/message_encoder.go
+++ b/comm/message_encoder.go
@@ -5,19 +5,14 @@ import (
 )
 
 type MessageEncoder interface {
+	Unmarshal(data []byte, v interface{}) error
 	MarshalReply(message *common.Reply) ([]byte, error)
 	MarshalPing(message *common.PingMessage) ([]byte, error)
 	MarshalDisconnect(message *common.DisconnectMessage) ([]byte, error)
 	MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error)
 	MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error)
-	Unmarshal(data []byte, v interface{}) error
 }
 
-var messageEncoder MessageEncoder
-
 func GetMessageEncoder() MessageEncoder {
-	if messageEncoder == nil {
-		messageEncoder = jsonEncoder{}
-	}
-	return messageEncoder
+	return jsonEncoder{}
 }

--- a/comm/message_encoder.go
+++ b/comm/message_encoder.go
@@ -1,0 +1,23 @@
+package comm
+
+import (
+	"github.com/anycable/anycable-go/common"
+)
+
+type MessageEncoder interface {
+	MarshalReply(v interface{}) ([]byte, error)
+	MarshalPing(v interface{}) ([]byte, error)
+	MarshalDisconnect(v interface{}) ([]byte, error)
+	MarshalTransmissions(transmissions []string, msg *common.Message) ([][]byte, error)
+	MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error)
+	Unmarshal(data []byte, v interface{}) error
+}
+
+var messageEncoder MessageEncoder
+
+func GetMessageEncoder() MessageEncoder {
+	if messageEncoder == nil {
+		messageEncoder = jsonEncoder{}
+	}
+	return messageEncoder
+}

--- a/comm/message_encoder.go
+++ b/comm/message_encoder.go
@@ -2,13 +2,12 @@ package comm
 
 import (
 	"github.com/anycable/anycable-go/common"
-	"github.com/anycable/anycable-go/node"
 )
 
 type MessageEncoder interface {
-	MarshalReply(message *node.Reply) ([]byte, error)
-	MarshalPing(message *node.PingMessage) ([]byte, error)
-	MarshalDisconnect(message *node.DisconnectMessage) ([]byte, error)
+	MarshalReply(message *common.Reply) ([]byte, error)
+	MarshalPing(message *common.PingMessage) ([]byte, error)
+	MarshalDisconnect(message *common.DisconnectMessage) ([]byte, error)
 	MarshalTransmissions(transmissions []string, message *common.Message) ([][]byte, error)
 	MarshalAuthenticateTransmissions(transmissions []string) ([][]byte, error)
 	Unmarshal(data []byte, v interface{}) error

--- a/common/common.go
+++ b/common/common.go
@@ -138,6 +138,26 @@ type RemoteDisconnectMessage struct {
 	Reconnect  bool   `json:"reconnect"`
 }
 
+// PingMessage represents a server ping
+type PingMessage struct {
+	Type    string      `json:"type"`
+	Message interface{} `json:"message"`
+}
+
+// DisconnectMessage represents a server disconnect message
+type DisconnectMessage struct {
+	Type      string `json:"type"`
+	Reason    string `json:"reason"`
+	Reconnect bool   `json:"reconnect"`
+}
+
+// Reply represents outgoing client message
+type Reply struct {
+	Type       string      `json:"type,omitempty"`
+	Identifier string      `json:"identifier"`
+	Message    interface{} `json:"message"`
+}
+
 // PubSubMessageFromJSON takes raw JSON byte array and return the corresponding struct
 func PubSubMessageFromJSON(raw []byte) (interface{}, error) {
 	smsg := StreamMessage{}

--- a/node/hub.go
+++ b/node/hub.go
@@ -24,7 +24,7 @@ type Reply struct {
 }
 
 func (r *Reply) encodeMessage() []byte {
-	msg, err := comm.GetMessageEncoder().MarshalReply(&r)
+	msg, err := comm.GetMessageEncoder().MarshalReply(r)
 	if err != nil {
 		panic("Failed to build message")
 	}

--- a/node/hub.go
+++ b/node/hub.go
@@ -285,7 +285,7 @@ func (h *Hub) broadcastToStream(stream string, data string) {
 				buf[id] = bdata
 			}
 
-			session.Send(bdata)
+			session.Send(bdata, comm.GetMessageEncoder().MarshalIsBinary())
 		}
 	}
 }
@@ -302,7 +302,7 @@ func (h *Hub) disconnectSessions(identifier string, reconnect bool) {
 
 	for id := range ids {
 		if ses, ok := h.sessions[id]; ok {
-			ses.Send(disconnectMessage)
+			ses.Send(disconnectMessage, comm.GetMessageEncoder().MarshalIsBinary())
 			ses.Disconnect("Closed remotely", CloseNormalClosure)
 		}
 	}

--- a/node/hub.go
+++ b/node/hub.go
@@ -16,14 +16,7 @@ type SubscriptionInfo struct {
 	identifier string
 }
 
-// Reply represents outgoing client message
-type Reply struct {
-	Type       string      `json:"type,omitempty"`
-	Identifier string      `json:"identifier"`
-	Message    interface{} `json:"message"`
-}
-
-func (r *Reply) encodeMessage() []byte {
+func encodeReplyMessage(r *common.Reply) []byte {
 	msg, err := comm.GetMessageEncoder().MarshalReply(r)
 	if err != nil {
 		panic("Failed to build message")
@@ -321,5 +314,5 @@ func buildBroadcastMessage(data string, identifier string) []byte {
 	// We ignore JSON deserialization failures and consider the message to be a string
 	json.Unmarshal([]byte(data), &msg) // nolint:errcheck
 
-	return (&Reply{Identifier: identifier, Message: msg}).encodeMessage()
+	return encodeReplyMessage(&common.Reply{Identifier: identifier, Message: msg})
 }

--- a/node/hub_test.go
+++ b/node/hub_test.go
@@ -176,12 +176,12 @@ func TestSubscribeSession(t *testing.T) {
 
 func TestBuildMessageJSON(t *testing.T) {
 	expected := []byte("{\"identifier\":\"chat\",\"message\":{\"text\":\"hello!\"}}")
-	actual := buildMessage("{\"text\":\"hello!\"}", "chat")
+	actual := buildBroadcastMessage("{\"text\":\"hello!\"}", "chat")
 	assert.Equal(t, expected, actual)
 }
 
 func TestBuildMessageString(t *testing.T) {
 	expected := []byte("{\"identifier\":\"chat\",\"message\":\"plain string\"}")
-	actual := buildMessage("\"plain string\"", "chat")
+	actual := buildBroadcastMessage("\"plain string\"", "chat")
 	assert.Equal(t, expected, actual)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -33,14 +33,14 @@ const (
 	metricsUnknownBroadcast = "failed_broadcast_msg_total"
 )
 
-type disconnectMessage struct {
+type DisconnectMessage struct {
 	Type      string `json:"type"`
 	Reason    string `json:"reason"`
 	Reconnect bool   `json:"reconnect"`
 }
 
-func (d *disconnectMessage) encodeMessage() []byte {
-	msg, err := comm.GetMessageEncoder().MarshalDisconnect(&d)
+func (d *DisconnectMessage) encodeMessage() []byte {
+	msg, err := comm.GetMessageEncoder().MarshalDisconnect(d)
 	if err != nil {
 		panic("Failed to build disconnect message 😲")
 	}
@@ -442,5 +442,5 @@ func subscriptionsList(m map[string]bool) []string {
 }
 
 func newDisconnectMessage(reason string, reconnect bool) []byte {
-	return (&disconnectMessage{Type: "disconnect", Reason: reason, Reconnect: reconnect}).encodeMessage()
+	return (&DisconnectMessage{Type: "disconnect", Reason: reason, Reconnect: reconnect}).encodeMessage()
 }

--- a/node/node.go
+++ b/node/node.go
@@ -33,13 +33,7 @@ const (
 	metricsUnknownBroadcast = "failed_broadcast_msg_total"
 )
 
-type DisconnectMessage struct {
-	Type      string `json:"type"`
-	Reason    string `json:"reason"`
-	Reconnect bool   `json:"reconnect"`
-}
-
-func (d *DisconnectMessage) encodeMessage() []byte {
+func encodeDisconnectMessage(d *common.DisconnectMessage) []byte {
 	msg, err := comm.GetMessageEncoder().MarshalDisconnect(d)
 	if err != nil {
 		panic("Failed to build disconnect message 😲")
@@ -442,5 +436,5 @@ func subscriptionsList(m map[string]bool) []string {
 }
 
 func newDisconnectMessage(reason string, reconnect bool) []byte {
-	return (&DisconnectMessage{Type: "disconnect", Reason: reason, Reconnect: reconnect}).encodeMessage()
+	return encodeDisconnectMessage(&common.DisconnectMessage{Type: "disconnect", Reason: reason, Reconnect: reconnect})
 }

--- a/node/node.go
+++ b/node/node.go
@@ -142,7 +142,7 @@ func (n *Node) Shutdown() {
 			disconnectMessage := newDisconnectMessage(serverRestartReason, true)
 			// Close all registered sessions
 			for _, session := range n.hub.sessions {
-				session.Send(disconnectMessage)
+				session.Send(disconnectMessage, comm.GetMessageEncoder().MarshalIsBinary())
 				session.Disconnect("Shutdown", CloseGoingAway)
 			}
 
@@ -320,7 +320,7 @@ func (n *Node) RemoteDisconnect(msg *common.RemoteDisconnectMessage) {
 
 func transmit(s *Session, transmissions [][]byte) {
 	for _, msg := range transmissions {
-		s.Send(msg)
+		s.Send(msg, comm.GetMessageEncoder().MarshalIsBinary())
 	}
 }
 

--- a/node/session.go
+++ b/node/session.go
@@ -113,12 +113,9 @@ func NewSession(node *Node, ws *websocket.Conn, url string, headers map[string]s
 func (s *Session) SendMessages() {
 	defer s.Disconnect("Write Failed", CloseAbnormalClosure)
 	for message := range s.send {
-		binaryMessageType := false
 		switch message.frameType {
-		case binaryFrame:
-			binaryMessageType = true
-		case textFrame:
-			err := s.write(message.payload, time.Now().Add(writeWait), binaryMessageType)
+		case textFrame, binaryFrame:
+			err := s.write(message.payload, time.Now().Add(writeWait), message.frameType == binaryFrame)
 
 			if err != nil {
 				return

--- a/node/session.go
+++ b/node/session.go
@@ -67,12 +67,7 @@ type Session struct {
 	Log         *log.Entry
 }
 
-type PingMessage struct {
-	Type    string      `json:"type"`
-	Message interface{} `json:"message"`
-}
-
-func (p *PingMessage) encodeMessage() []byte {
+func encodePingMessage(p *common.PingMessage) []byte {
 	msg, err := comm.GetMessageEncoder().MarshalPing(p)
 	if err != nil {
 		panic("Failed to build ping message 😲")
@@ -266,5 +261,5 @@ func (s *Session) addPing() {
 }
 
 func newPingMessage() []byte {
-	return (&PingMessage{Type: "ping", Message: time.Now().Unix()}).encodeMessage()
+	return encodePingMessage(&common.PingMessage{Type: "ping", Message: time.Now().Unix()})
 }

--- a/node/session.go
+++ b/node/session.go
@@ -67,13 +67,13 @@ type Session struct {
 	Log         *log.Entry
 }
 
-type pingMessage struct {
+type PingMessage struct {
 	Type    string      `json:"type"`
 	Message interface{} `json:"message"`
 }
 
-func (p *pingMessage) encodeMessage() []byte {
-	msg, err := comm.GetMessageEncoder().MarshalPing(&p)
+func (p *PingMessage) encodeMessage() []byte {
+	msg, err := comm.GetMessageEncoder().MarshalPing(p)
 	if err != nil {
 		panic("Failed to build ping message 😲")
 	}
@@ -266,5 +266,5 @@ func (s *Session) addPing() {
 }
 
 func newPingMessage() []byte {
-	return (&pingMessage{Type: "ping", Message: time.Now().Unix()}).encodeMessage()
+	return (&PingMessage{Type: "ping", Message: time.Now().Unix()}).encodeMessage()
 }

--- a/node/session.go
+++ b/node/session.go
@@ -134,8 +134,12 @@ func (s *Session) SendMessages() {
 }
 
 // Send data to client connection
-func (s *Session) Send(msg []byte) {
-	s.sendFrame(&sentFrame{frameType: textFrame, payload: msg})
+func (s *Session) Send(msg []byte, binary bool) {
+	frameType := textFrame
+	if binary {
+		frameType = binaryFrame
+	}
+	s.sendFrame(&sentFrame{frameType: frameType, payload: msg})
 }
 
 func (s *Session) sendClose(reason string, code int) {

--- a/node/session.go
+++ b/node/session.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"encoding/json"
+	"github.com/anycable/anycable-go/comm"
 	"sync"
 	"time"
 
@@ -72,12 +72,12 @@ type pingMessage struct {
 	Message interface{} `json:"message"`
 }
 
-func (p *pingMessage) toJSON() []byte {
-	jsonStr, err := json.Marshal(&p)
+func (p *pingMessage) encodeMessage() []byte {
+	msg, err := comm.GetMessageEncoder().MarshalPing(&p)
 	if err != nil {
-		panic("Failed to build ping JSON 😲")
+		panic("Failed to build ping message 😲")
 	}
-	return jsonStr
+	return msg
 }
 
 // NewSession build a new Session struct from ws connetion and http request
@@ -266,5 +266,5 @@ func (s *Session) addPing() {
 }
 
 func newPingMessage() []byte {
-	return (&pingMessage{Type: "ping", Message: time.Now().Unix()}).toJSON()
+	return (&pingMessage{Type: "ping", Message: time.Now().Unix()}).encodeMessage()
 }

--- a/node/session_test.go
+++ b/node/session_test.go
@@ -16,12 +16,12 @@ func TestSendRaceConditions(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			go func() {
-				session.Send([]byte("hi!"))
+				session.Send([]byte("hi!"), false)
 				wg.Done()
 			}()
 
 			go func() {
-				session.Send([]byte("bye"))
+				session.Send([]byte("bye"), false)
 				wg.Done()
 			}()
 		}()
@@ -29,12 +29,12 @@ func TestSendRaceConditions(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			go func() {
-				session.Send([]byte("bye"))
+				session.Send([]byte("bye"), false)
 				wg.Done()
 			}()
 
 			go func() {
-				session.Send([]byte("why"))
+				session.Send([]byte("why"), false)
 				wg.Done()
 			}()
 		}()


### PR DESCRIPTION
# Work in Progress - do not merge

### What is the purpose of this pull request?
Abstracted the JSON message encoding into a single interface (MessageEncoder) so it can be replaced with custom encoders more easily. See #91 

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation
