### PR TITLE
re-add git version to LD_FLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- re-added git ref version to `LD_FLAGS` in Makefile
+
 ## 1.0.1 (2020-07-07)
 
 - Fix subscribing to the same stream from different channels. ([@palkan][])

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifdef VERSION
 else
 	COMMIT := $(shell sh -c 'git log --pretty=format:"%h" -n 1 ')
 	VERSION := $(shell sh -c 'git tag -l --sort=-version:refname "v*" | head -n1')
-	LD_FLAGS="-s -w -X github.com/anycable/anycable-go/utils.sha=$(COMMIT) -X github.com/anycable/anycable-go/utils.version="
+	LD_FLAGS="-s -w -X github.com/anycable/anycable-go/utils.sha=$(COMMIT) -X github.com/anycable/anycable-go/utils.version=$(VERSION)"
 endif
 
 GOBUILD=go build -ldflags $(LD_FLAGS) -a


### PR DESCRIPTION
It seems the git ref version determination in the Makefile has gone missing, this PR simply adds it again.