### PR TITLE
Externalize message structs into common package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- moved pingMessage (session), disconnectMessage (node) and Reply (hub) structs into common package
+
 ## 1.0.1 (2020-07-07)
 
 - Fix subscribing to the same stream from different channels. ([@palkan][])

--- a/common/common.go
+++ b/common/common.go
@@ -152,6 +152,21 @@ func (p *PingMessage) ToJSON() []byte {
 	return jsonStr
 }
 
+// DisconnectMessage represents a server disconnect message
+type DisconnectMessage struct {
+	Type      string `json:"type"`
+	Reason    string `json:"reason"`
+	Reconnect bool   `json:"reconnect"`
+}
+
+func (d *DisconnectMessage) ToJSON() []byte {
+	jsonStr, err := json.Marshal(&d)
+	if err != nil {
+		panic("Failed to build disconnect JSON 😲")
+	}
+	return jsonStr
+}
+
 // PubSubMessageFromJSON takes raw JSON byte array and return the corresponding struct
 func PubSubMessageFromJSON(raw []byte) (interface{}, error) {
 	smsg := StreamMessage{}

--- a/common/common.go
+++ b/common/common.go
@@ -138,6 +138,20 @@ type RemoteDisconnectMessage struct {
 	Reconnect  bool   `json:"reconnect"`
 }
 
+// PingMessage represents a server ping
+type PingMessage struct {
+	Type    string      `json:"type"`
+	Message interface{} `json:"message"`
+}
+
+func (p *PingMessage) ToJSON() []byte {
+	jsonStr, err := json.Marshal(&p)
+	if err != nil {
+		panic("Failed to build ping JSON 😲")
+	}
+	return jsonStr
+}
+
 // PubSubMessageFromJSON takes raw JSON byte array and return the corresponding struct
 func PubSubMessageFromJSON(raw []byte) (interface{}, error) {
 	smsg := StreamMessage{}

--- a/common/common.go
+++ b/common/common.go
@@ -167,6 +167,21 @@ func (d *DisconnectMessage) ToJSON() []byte {
 	return jsonStr
 }
 
+// Reply represents an outgoing client message
+type Reply struct {
+	Type       string      `json:"type,omitempty"`
+	Identifier string      `json:"identifier"`
+	Message    interface{} `json:"message"`
+}
+
+func (r *Reply) ToJSON() []byte {
+	jsonStr, err := json.Marshal(&r)
+	if err != nil {
+		panic("Failed to build JSON")
+	}
+	return jsonStr
+}
+
 // PubSubMessageFromJSON takes raw JSON byte array and return the corresponding struct
 func PubSubMessageFromJSON(raw []byte) (interface{}, error) {
 	smsg := StreamMessage{}

--- a/node/hub.go
+++ b/node/hub.go
@@ -15,21 +15,6 @@ type SubscriptionInfo struct {
 	identifier string
 }
 
-// Reply represents outgoing client message
-type Reply struct {
-	Type       string      `json:"type,omitempty"`
-	Identifier string      `json:"identifier"`
-	Message    interface{} `json:"message"`
-}
-
-func (r *Reply) toJSON() []byte {
-	jsonStr, err := json.Marshal(&r)
-	if err != nil {
-		panic("Failed to build JSON")
-	}
-	return jsonStr
-}
-
 // Hub stores all the sessions and the corresponding subscriptions info
 type Hub struct {
 	// Registered sessions
@@ -320,5 +305,5 @@ func buildMessage(data string, identifier string) []byte {
 	// We ignore JSON deserialization failures and consider the message to be a string
 	json.Unmarshal([]byte(data), &msg) // nolint:errcheck
 
-	return (&Reply{Identifier: identifier, Message: msg}).toJSON()
+	return (&common.Reply{Identifier: identifier, Message: msg}).ToJSON()
 }

--- a/node/node.go
+++ b/node/node.go
@@ -33,20 +33,6 @@ const (
 	metricsUnknownBroadcast = "failed_broadcast_msg_total"
 )
 
-type disconnectMessage struct {
-	Type      string `json:"type"`
-	Reason    string `json:"reason"`
-	Reconnect bool   `json:"reconnect"`
-}
-
-func (d *disconnectMessage) toJSON() []byte {
-	jsonStr, err := json.Marshal(&d)
-	if err != nil {
-		panic("Failed to build disconnect JSON 😲")
-	}
-	return jsonStr
-}
-
 // AppNode describes a basic node interface
 type AppNode interface {
 	HandlePubSub(msg []byte)
@@ -424,5 +410,5 @@ func subscriptionsList(m map[string]bool) []string {
 }
 
 func newDisconnectMessage(reason string, reconnect bool) []byte {
-	return (&disconnectMessage{Type: "disconnect", Reason: reason, Reconnect: reconnect}).toJSON()
+	return (&common.DisconnectMessage{Type: "disconnect", Reason: reason, Reconnect: reconnect}).ToJSON()
 }

--- a/node/session.go
+++ b/node/session.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"encoding/json"
 	"sync"
 	"time"
 
@@ -65,19 +64,6 @@ type Session struct {
 	UID         string
 	Identifiers string
 	Log         *log.Entry
-}
-
-type pingMessage struct {
-	Type    string      `json:"type"`
-	Message interface{} `json:"message"`
-}
-
-func (p *pingMessage) toJSON() []byte {
-	jsonStr, err := json.Marshal(&p)
-	if err != nil {
-		panic("Failed to build ping JSON 😲")
-	}
-	return jsonStr
 }
 
 // NewSession build a new Session struct from ws connetion and http request
@@ -266,5 +252,5 @@ func (s *Session) addPing() {
 }
 
 func newPingMessage() []byte {
-	return (&pingMessage{Type: "ping", Message: time.Now().Unix()}).toJSON()
+	return (&common.PingMessage{Type: "ping", Message: time.Now().Unix()}).ToJSON()
 }


### PR DESCRIPTION
### What is the purpose of this pull request?
Move message structs into common package.

### What changes did you make? (overview)
Made pingMessage, disconnectMessage and Reply public members of the common package, together with their toJSON (now ToJSON) functions.

### Is there anything you'd like reviewers to focus on?
No - if tests still run, it worked. :)

### Checklist
- [X] I've added a Changelog entry
