### PR TITLE
CI: Build MacOS and Linux binaries for master and specified commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,16 @@ jobs:
       run: make prepare-mruby
     - name: Run tests
       run: go test -tags mrb ./...
+    - name: Build
+      if: matrix['go-version'] == '1.15.x' && (contains(github.ref, 'master') || contains(github.event.pull_request.body, '[Build]'))
+      run: |
+        make build
+    - name: Upload linux build
+      if: matrix['go-version'] == '1.15.x' && (contains(github.ref, 'master') || contains(github.event.pull_request.body, '[Build]'))
+      uses: actions/upload-artifact@v1
+      with:
+        name: anycable-go-Linux-x86_64
+        path: dist/anycable-go
 
   test-macos:
     strategy:
@@ -49,6 +59,16 @@ jobs:
       run: make prepare-mruby
     - name: Run tests
       run: go test -tags mrb ./...
+    - name: Build
+      if: matrix['go-version'] == '1.15.x' && (contains(github.ref, 'master') || contains(github.event.pull_request.body, '[Build]'))
+      run: |
+        make build
+    - name: Upload linux build
+      if: matrix['go-version'] == '1.15.x' && (contains(github.ref, 'master') || contains(github.event.pull_request.body, '[Build]'))
+      uses: actions/upload-artifact@v1
+      with:
+        name: anycable-go-Darwin-x86_64
+        path: dist/anycable-go
 
   test-conformance:
     needs: [test, test-macos]


### PR DESCRIPTION
- MacOS and Linux binaries are built automatically for every commit from master
- Binaries for PRs are built iff "[Build]" string is present in the PR description (useful for public testing of experimental features or triages)