### PR TITLE
RPC pending calls metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Added `rpc_pending_num` metric. ([@palkan][])
+
 ## 1.0.2 (2020-09-08)
 
 - Add channel states to `disconnect` requests. ([@palkan][])

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -51,6 +51,10 @@ anycable_go_rpc_error_total 0
 # TYPE anycable_go_rpc_retries_total counter
 anycable_go_rpc_retries_total 0
 
+# HELP anycable_go_rpc_pending_num The number of pending RPC calls
+# TYPE anycable_go_rpc_pending_num gauge
+anycable_go_rpc_pending_num 0
+
 # HELP anycable_go_failed_auths_total The total number of failed authentication attempts
 # TYPE anycable_go_failed_auths_total counter
 anycable_go_failed_auths_total 0

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -31,6 +31,16 @@ func (g *Gauge) Set(value int) {
 	atomic.StoreInt64(&g.value, int64(value))
 }
 
+// Inc increment the current value by 1
+func (g *Gauge) Inc() int64 {
+	return atomic.AddInt64(&g.value, 1)
+}
+
+// Dec decrement the current value by 1
+func (g *Gauge) Dec() int64 {
+	return atomic.AddInt64(&g.value, -1)
+}
+
 // Set64 sets gauge value as int64
 func (g *Gauge) Set64(value int64) {
 	atomic.StoreInt64(&g.value, value)

--- a/metrics/gauge_test.go
+++ b/metrics/gauge_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,4 +12,32 @@ func TestGauge(t *testing.T) {
 	assert.Equal(t, int64(0), g.Value())
 	g.Set(20)
 	assert.Equal(t, int64(20), g.Value())
+}
+
+func TestGaugeIncDec(t *testing.T) {
+	g := NewGauge("test", "")
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+
+		go func() {
+			g.Inc()
+			wg.Done()
+		}()
+	}
+
+	for i := 0; i < 13; i++ {
+		wg.Add(1)
+
+		go func() {
+			g.Dec()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(7), g.Value())
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -164,7 +164,7 @@ func (m *Metrics) RegisterCounter(name string, desc string) {
 	m.counters[name] = NewCounter(name, desc)
 }
 
-// RegisterGauge adds new counter to the registry
+// RegisterGauge adds new gauge to the registry
 func (m *Metrics) RegisterGauge(name string, desc string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
### What is the purpose of this pull request?

Add a metric to track the size of the RPC calls queue (`rpc_pending_num`). This metrics could be used in auto-scaling strategies.

### What changes did you make? (overview)

- [x] Introduce new gauge metric, `rpc_pending_num`, to rpc.Controller

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation

