### PR TITLE
Set pre-release flag in GitHub releases only for versions with suffix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,4 +502,8 @@ jobs:
         command: env GO111MODULE=off go get github.com/tcnksm/ghr
     - run:
         name: Upload GitHub release
-        command: ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete ${CIRCLE_TAG} ./
+        command: |
+          # Add pre-release option if tag name has any suffix after vMAJOR.MINOR.PATCH (e.g. v1.2.3-beta)
+          [[ ${CIRCLE_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+.+ ]] && prerelease="-prerelease"
+          # Publish release
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} $prerelease -delete ${CIRCLE_TAG} ./


### PR DESCRIPTION
Last releases ([1.0.2](https://github.com/anycable/anycable-go/releases/tag/v1.0.2) and [1.0.1](https://github.com/anycable/anycable-go/releases/tag/v1.0.1)) are marked as pre-release due to using of `-prerelease` option for `ghr` tool.

I added logic to set this flag only for releases for versions with extra suffix to version.

For example:

 - `v1.2.3` is a regular release
 - `v1.2.3-preview1` is a pre-release