### PR TITLE
Extract protocol utils from rpc package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.35
   vet:
     runs-on: ubuntu-latest
     steps:

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,0 +1,136 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/anycable/anycable-go/common"
+
+	pb "github.com/anycable/anycable-go/protos"
+)
+
+// NewConnectMessage builds a connect RPC payload from the session env
+func NewConnectMessage(env *common.SessionEnv) *pb.ConnectionRequest {
+	return &pb.ConnectionRequest{
+		Path:    env.URL,
+		Headers: *env.Headers,
+		Env:     buildEnv(env),
+	}
+}
+
+// NewCommandMessage builds a command RPC payload from the session env, command and channel names,
+// and connection identifiers
+func NewCommandMessage(env *common.SessionEnv, command string, channel string, identifiers string, data string) *pb.CommandMessage {
+	msg := pb.CommandMessage{
+		Command:               command,
+		Env:                   buildChannelEnv(channel, env),
+		Identifier:            channel,
+		ConnectionIdentifiers: identifiers,
+	}
+
+	if data != "" {
+		msg.Data = data
+	}
+
+	return &msg
+}
+
+// NewDisconnectMessage builds a disconnect RPC payload from the session env, connection identifiers and
+// subscriptions
+func NewDisconnectMessage(env *common.SessionEnv, identifiers string, subscriptions []string) *pb.DisconnectRequest {
+	return &pb.DisconnectRequest{
+		Identifiers:   identifiers,
+		Subscriptions: subscriptions,
+		Path:          env.URL,
+		Headers:       *env.Headers,
+		Env:           buildDisconnectEnv(env),
+	}
+}
+
+// ParseConnectResponse takes protobuf ConnectionResponse struct and converts into common.ConnectResult and/or error
+func ParseConnectResponse(response *pb.ConnectionResponse) (*common.ConnectResult, error) {
+	reply := common.ConnectResult{Transmissions: response.Transmissions}
+
+	if response.Env != nil {
+		reply.CState = response.Env.Cstate
+	}
+
+	if response.Status.String() == "SUCCESS" {
+		reply.Identifier = response.Identifiers
+		return &reply, nil
+	}
+
+	return &reply, fmt.Errorf("Application error: %s", response.ErrorMsg)
+}
+
+// ParseCommandResponse takes protobuf CommandResponse struct and converts into common.CommandResult and/or error
+func ParseCommandResponse(response *pb.CommandResponse) (*common.CommandResult, error) {
+	res := &common.CommandResult{
+		Disconnect:     response.Disconnect,
+		StopAllStreams: response.StopStreams,
+		Streams:        response.Streams,
+		StoppedStreams: response.StoppedStreams,
+		Transmissions:  response.Transmissions,
+	}
+
+	if response.Env != nil {
+		res.CState = response.Env.Cstate
+		res.IState = response.Env.Istate
+	}
+
+	if response.Status.String() == "SUCCESS" {
+		return res, nil
+	}
+
+	return res, fmt.Errorf("Application error: %s", response.ErrorMsg)
+}
+
+// ParseDisconnectResponse takes protobuf DisconnectResponse struct and return error if any
+func ParseDisconnectResponse(response *pb.DisconnectResponse) error {
+	if response.Status.String() == "SUCCESS" {
+		return nil
+	}
+
+	return fmt.Errorf("Application error: %s", response.ErrorMsg)
+}
+
+func buildEnv(env *common.SessionEnv) *pb.Env {
+	protoEnv := pb.Env{Url: env.URL, Headers: *env.Headers}
+	if env.ConnectionState != nil {
+		protoEnv.Cstate = *env.ConnectionState
+	}
+	return &protoEnv
+}
+
+func buildDisconnectEnv(env *common.SessionEnv) *pb.Env {
+	protoEnv := *buildEnv(env)
+
+	if env.ChannelStates == nil {
+		return &protoEnv
+	}
+
+	states := make(map[string]string)
+
+	for id, state := range *env.ChannelStates {
+		encodedState, _ := json.Marshal(state)
+
+		states[id] = string(encodedState)
+	}
+
+	protoEnv.Istate = states
+
+	return &protoEnv
+}
+
+func buildChannelEnv(id string, env *common.SessionEnv) *pb.Env {
+	protoEnv := *buildEnv(env)
+
+	if env.ChannelStates == nil {
+		return &protoEnv
+	}
+
+	if _, ok := (*env.ChannelStates)[id]; ok {
+		protoEnv.Istate = (*env.ChannelStates)[id]
+	}
+	return &protoEnv
+}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,0 +1,188 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anycable/anycable-go/common"
+
+	pb "github.com/anycable/anycable-go/protos"
+)
+
+func buildSessionEnv() *common.SessionEnv {
+	url := "/cable-test"
+	headers := map[string]string{"cookie": "token=secret;"}
+
+	return &common.SessionEnv{URL: url, Headers: &headers}
+}
+
+func TestNewConnectMessage(t *testing.T) {
+	env := buildSessionEnv()
+
+	msg := NewConnectMessage(env)
+
+	assert.Equal(t, "/cable-test", msg.Path)
+	assert.Equal(t, map[string]string{"cookie": "token=secret;"}, msg.Headers)
+	assert.NotNil(t, msg.Env)
+	assert.Equal(t, "/cable-test", msg.Env.Url)
+	assert.Equal(t, map[string]string{"cookie": "token=secret;"}, msg.Env.Headers)
+}
+
+func TestNewCommandMessage(t *testing.T) {
+	t.Run("Base", func(t *testing.T) {
+		env := buildSessionEnv()
+
+		msg := NewCommandMessage(env, "subscribe", "test_channel", "user=john", "")
+
+		assert.Equal(t, "subscribe", msg.Command)
+		assert.Equal(t, "test_channel", msg.Identifier)
+		assert.Equal(t, "user=john", msg.ConnectionIdentifiers)
+		assert.NotNil(t, msg.Env)
+
+		assert.NotNil(t, "/cable-test", msg.Env.Url)
+		assert.Equal(t, map[string]string{"cookie": "token=secret;"}, msg.Env.Headers)
+	})
+
+	t.Run("With connection, channel state and data", func(t *testing.T) {
+		env := buildSessionEnv()
+		cstate := map[string]string{"_s_": "id=42"}
+		env.ConnectionState = &cstate
+
+		istate := map[string]string{"room": "room:1"}
+		channels := make(map[string]map[string]string)
+		channels["test_channel"] = istate
+
+		env.ChannelStates = &channels
+
+		msg := NewCommandMessage(env, "subscribe", "test_channel", "user=john", "action")
+
+		assert.Equal(t, "subscribe", msg.Command)
+		assert.Equal(t, "test_channel", msg.Identifier)
+		assert.Equal(t, "user=john", msg.ConnectionIdentifiers)
+		assert.Equal(t, "action", msg.Data)
+		assert.NotNil(t, msg.Env)
+
+		assert.Equal(t, cstate, msg.Env.Cstate)
+		assert.Equal(t, istate, msg.Env.Istate)
+	})
+}
+
+func TestNewDisconnectRequest(t *testing.T) {
+	env := buildSessionEnv()
+
+	cstate := map[string]string{"_s_": "id=42"}
+	istate := map[string]string{"test_channel": "{\"room\":\"room:1\"}"}
+
+	channels := make(map[string]map[string]string)
+	channels["test_channel"] = map[string]string{"room": "room:1"}
+
+	env.ConnectionState = &cstate
+	env.ChannelStates = &channels
+
+	msg := NewDisconnectMessage(env, "user=john", []string{"chat_42"})
+
+	assert.Equal(t, "user=john", msg.Identifiers)
+	assert.Equal(t, []string{"chat_42"}, msg.Subscriptions)
+	assert.Equal(t, cstate, msg.Env.Cstate)
+	assert.Equal(t, istate, msg.Env.Istate)
+}
+
+func TestParseConnectResponse(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		res := pb.ConnectionResponse{
+			Identifiers:   "user=john",
+			Transmissions: []string{"welcome"},
+			Status:        pb.Status_SUCCESS,
+			Env:           &pb.EnvResponse{Cstate: map[string]string{"_s_": "test-session"}},
+		}
+
+		result, err := ParseConnectResponse(&res)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "user=john", result.Identifier)
+		assert.Equal(t, []string{"welcome"}, result.Transmissions)
+		assert.Equal(t, map[string]string{"_s_": "test-session"}, result.CState)
+	})
+	t.Run("Failure", func(t *testing.T) {
+		res := pb.ConnectionResponse{
+			Transmissions: []string{"unauthorized"},
+			Status:        pb.Status_FAILURE,
+			Env:           &pb.EnvResponse{Cstate: map[string]string{"_s_": "test-session"}},
+			ErrorMsg:      "Authentication failed",
+		}
+
+		_, err := ParseConnectResponse(&res)
+
+		assert.NotNil(t, err)
+	})
+}
+
+func TestParseCommandResponse(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		res := pb.CommandResponse{
+			Status:         pb.Status_SUCCESS,
+			Streams:        []string{"chat_42"},
+			StoppedStreams: []string{"chat_41"},
+			StopStreams:    true,
+			Transmissions:  []string{"message_sent"},
+		}
+
+		result, err := ParseCommandResponse(&res)
+
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"chat_42"}, result.Streams)
+		assert.Equal(t, []string{"message_sent"}, result.Transmissions)
+		assert.Equal(t, true, result.StopAllStreams)
+		assert.Equal(t, []string{"chat_41"}, result.StoppedStreams)
+	})
+
+	t.Run("Success with connection and channel state", func(t *testing.T) {
+		res := pb.CommandResponse{
+			Status:        pb.Status_SUCCESS,
+			Streams:       []string{"chat_42"},
+			Env:           &pb.EnvResponse{Cstate: map[string]string{"_s_": "sentCount=1"}, Istate: map[string]string{"count": "1"}},
+			Transmissions: []string{"message_sent"},
+		}
+
+		result, err := ParseCommandResponse(&res)
+
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"chat_42"}, result.Streams)
+		assert.Equal(t, []string{"message_sent"}, result.Transmissions)
+		assert.Equal(t, map[string]string{"_s_": "sentCount=1"}, result.CState)
+		assert.Equal(t, map[string]string{"count": "1"}, result.IState)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		res := pb.CommandResponse{
+			Status:   pb.Status_FAILURE,
+			ErrorMsg: "Unknown command",
+		}
+
+		_, err := ParseCommandResponse(&res)
+
+		assert.NotNil(t, err)
+	})
+}
+
+func TestParseDisconnectResponse(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		res := pb.DisconnectResponse{
+			Status: pb.Status_SUCCESS,
+		}
+
+		err := ParseDisconnectResponse(&res)
+
+		assert.Nil(t, err)
+	})
+	t.Run("Failure", func(t *testing.T) {
+		res := pb.DisconnectResponse{
+			Status: pb.Status_FAILURE,
+		}
+
+		err := ParseDisconnectResponse(&res)
+
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

Extract functionality which converts protobufs to internal structs and build protobufs.
This code could be used by future controllers.

### What changes did you make? (overview)

- Added `protocol` package.
- Moved protobuf building and "parsing" from `rpc` to `protocol`.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation
