### PR TITLE
Calculate IntervalDelta correctly if there are no changes to the counter

### DIFF
--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -34,7 +34,7 @@ func (c *Counter) Value() int64 {
 
 // IntervalValue allows to get last interval value for counter.
 func (c *Counter) IntervalValue() int64 {
-	if c.lastIntervalDelta == 0 {
+	if c.lastIntervalValue == 0 {
 		return c.Value()
 	}
 	return atomic.LoadInt64(&c.lastIntervalDelta)

--- a/metrics/counter_test.go
+++ b/metrics/counter_test.go
@@ -19,4 +19,10 @@ func TestCounter(t *testing.T) {
 	cnt.Inc()
 	assert.Equal(t, int64(1501), cnt.Value())
 	assert.Equal(t, int64(1500), cnt.IntervalValue())
+	cnt.UpdateDelta()
+	assert.Equal(t, int64(1501), cnt.Value())
+	assert.Equal(t, int64(1), cnt.IntervalValue())
+	cnt.UpdateDelta()
+	assert.Equal(t, int64(1501), cnt.Value())
+	assert.Equal(t, int64(0), cnt.IntervalValue())
 }


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


### What is the purpose of this pull request?
This PR fixes an issue where IntervalDelta is calculated incorrectly if there is no change to the counter between update interval.

### What changes did you make? (overview)
Fixed it check the last value being zero instead delta being zero.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation

