### PR TITLE
Add metrics for server messages sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Added `server_msg_total` and `failed_server_msg_total` metrics. ([@prburgu][])
+
 ## 1.0.5 (2021-03-17)
 
 - Fix interval values for counters. ([@prburgu][])

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -67,11 +67,11 @@ anycable_go_goroutines_num 5222
 # TYPE anycable_go_disconnect_queue_size gauge
 anycable_go_disconnect_queue_size 0
 
-# HELP server_msg_total The total number messages sent to the clients
+# HELP server_msg_total The total number of messages sent to clients
 # TYPE server_msg_total counter
 server_msg_total 453
 
-# HELP failed_server_msg_total The total number of messages failed to send to the clients
+# HELP failed_server_msg_total The total number of messages failed to send to clients
 # TYPE failed_server_msg_total counter
 failed_server_msg_total 0
 ```

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -67,13 +67,13 @@ anycable_go_goroutines_num 5222
 # TYPE anycable_go_disconnect_queue_size gauge
 anycable_go_disconnect_queue_size 0
 
-# HELP server_msg_total The total number of messages sent to clients
-# TYPE server_msg_total counter
-server_msg_total 453
+# HELP anycable_go_server_msg_total The total number of messages sent to clients
+# TYPE anycable_go_server_msg_total counter
+anycable_go_server_msg_total 453
 
-# HELP failed_server_msg_total The total number of messages failed to send to clients
-# TYPE failed_server_msg_total counter
-failed_server_msg_total 0
+# HELP anycable_go_failed_server_msg_total The total number of messages failed to send to clients
+# TYPE anycable_go_failed_server_msg_total counter
+anycable_go_failed_server_msg_total 0
 ```
 
 ## Logging

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -66,6 +66,14 @@ anycable_go_goroutines_num 5222
 # HELP anycable_go_disconnect_queue_size The size of delayed disconnect
 # TYPE anycable_go_disconnect_queue_size gauge
 anycable_go_disconnect_queue_size 0
+
+# HELP server_msg_total The total number messages sent to the clients
+# TYPE server_msg_total counter
+server_msg_total 453
+
+# HELP failed_server_msg_total The total number of messages failed to send to the clients
+# TYPE failed_server_msg_total counter
+failed_server_msg_total 0
 ```
 
 ## Logging

--- a/node/node.go
+++ b/node/node.go
@@ -404,7 +404,7 @@ func (n *Node) registerMetrics() {
 	n.Metrics.RegisterCounter(metricsBroadcastMsg, "The total number of messages received through PubSub (for broadcast)")
 	n.Metrics.RegisterCounter(metricsUnknownBroadcast, "The total number of unrecognized messages received through PubSub")
 	n.Metrics.RegisterCounter(metricsSentMsg, "The total number of messages sent to clients")
-	n.Metrics.RegisterCounter(metricsFailedSent, "The total number of messages failed to send to the clients")
+	n.Metrics.RegisterCounter(metricsFailedSent, "The total number of messages failed to send to clients")
 
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -403,7 +403,7 @@ func (n *Node) registerMetrics() {
 	n.Metrics.RegisterCounter(metricsUnknownReceived, "The total number of unrecognized messages received from clients")
 	n.Metrics.RegisterCounter(metricsBroadcastMsg, "The total number of messages received through PubSub (for broadcast)")
 	n.Metrics.RegisterCounter(metricsUnknownBroadcast, "The total number of unrecognized messages received through PubSub")
-	n.Metrics.RegisterCounter(metricsSentMsg, "The total number messages sent to the clients")
+	n.Metrics.RegisterCounter(metricsSentMsg, "The total number of messages sent to clients")
 	n.Metrics.RegisterCounter(metricsFailedSent, "The total number of messages failed to send to the clients")
 
 }

--- a/node/node.go
+++ b/node/node.go
@@ -28,6 +28,8 @@ const (
 	metricsUnknownReceived  = "failed_client_msg_total"
 	metricsBroadcastMsg     = "broadcast_msg_total"
 	metricsUnknownBroadcast = "failed_broadcast_msg_total"
+	metricsSentMsg          = "server_msg_total"
+	metricsFailedSent       = "failed_server_msg_total"
 )
 
 // AppNode describes a basic node interface
@@ -401,6 +403,9 @@ func (n *Node) registerMetrics() {
 	n.Metrics.RegisterCounter(metricsUnknownReceived, "The total number of unrecognized messages received from clients")
 	n.Metrics.RegisterCounter(metricsBroadcastMsg, "The total number of messages received through PubSub (for broadcast)")
 	n.Metrics.RegisterCounter(metricsUnknownBroadcast, "The total number of unrecognized messages received through PubSub")
+	n.Metrics.RegisterCounter(metricsSentMsg, "The total number messages sent to the clients")
+	n.Metrics.RegisterCounter(metricsFailedSent, "The total number of messages failed to send to the clients")
+
 }
 
 func subscriptionsList(m map[string]bool) []string {

--- a/node/session.go
+++ b/node/session.go
@@ -24,10 +24,6 @@ const (
 	CloseGoingAway = websocket.CloseGoingAway
 
 	writeWait = 10 * time.Second
-
-	// Metrics
-	metricsSentMsg = "server_msg_total"
-	metricsFailedSent = "failed_server_msg_total"
 )
 
 var (

--- a/node/session.go
+++ b/node/session.go
@@ -105,10 +105,10 @@ func (s *Session) SendMessages() {
 			err := s.write(message.payload, time.Now().Add(writeWait))
 
 			if err != nil {
-				s.node.Metrics.Counter(metricsSentMsg).Inc()
+				s.node.Metrics.Counter(metricsFailedSent).Inc()
 				return
 			} else {
-				s.node.Metrics.Counter(metricsFailedSent).Inc()
+				s.node.Metrics.Counter(metricsSentMsg).Inc()
 			}
 		case closeFrame:
 			utils.CloseWS(s.ws, message.closeCode, message.closeReason)

--- a/node/session.go
+++ b/node/session.go
@@ -140,12 +140,16 @@ func (s *Session) sendFrame(frame *sentFrame) {
 
 	select {
 	case s.send <- *frame:
-		s.node.Metrics.Counter(metricsSentMsg).Inc()
+		if s.node != nil {
+			s.node.Metrics.Counter(metricsSentMsg).Inc()
+		}
 	default:
 		if s.send != nil {
 			close(s.send)
-			s.node.Metrics.Counter(metricsFailedSent).Inc()
 			defer s.Disconnect("Write failed", CloseAbnormalClosure)
+			if s.node != nil {
+				s.node.Metrics.Counter(metricsFailedSent).Inc()
+			}
 		}
 
 		s.send = nil


### PR DESCRIPTION
### What is the purpose of this pull request?
This PR adds metrics for the total number of messages sent and failed to send to clients. We'll be using these metrics monitor how many messages are being sent to clients and if there are any failures sending. This gives us signal whether service is functioning properly or having issues.

### What changes did you make? (overview)
Registered a new counter metrics and incremented the counters upon sending the message to clients.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
