### PR TITLE
Make ping timestamp format configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Added concurrency to broadcasting. ([@palkan][])
 
+- Made ping message timestamp precision configurable ([@prburgu][])
+
 Now new broadcast messages are handled (and retransmitted) concurrently by a pool of workers (Go routines).
 You can control the size of the pool via the `hub_gopool_size` configuration parameter (defaults to 16).
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -92,7 +92,7 @@ func init() {
 	fs.IntVar(&defaults.App.StatsRefreshInterval, "stats_refresh_interval", 5, "")
 	fs.IntVar(&defaults.App.HubGopoolSize, "hub_gopool_size", 16, "")
 
-	fs.StringVar(&defaults.App.PingTimestampFormat, "ping_timestamp_format", "s", "")
+	fs.StringVar(&defaults.App.PingTimestampPrecision, "ping_timestamp_precision", "s", "")
 
 	// CLI vars
 	fs.BoolVar(&showHelp, "h", false, "")

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -92,6 +92,8 @@ func init() {
 	fs.IntVar(&defaults.App.StatsRefreshInterval, "stats_refresh_interval", 5, "")
 	fs.IntVar(&defaults.App.HubGopoolSize, "hub_gopool_size", 16, "")
 
+	fs.StringVar(&defaults.App.PingTimestampFormat, "ping_timestamp_format", "s", "")
+
 	// CLI vars
 	fs.BoolVar(&showHelp, "h", false, "")
 	fs.BoolVar(&showVersion, "v", false, "")

--- a/node/config.go
+++ b/node/config.go
@@ -9,10 +9,10 @@ type Config struct {
 	// The max size of the Go routines pool for hub
 	HubGopoolSize int
 	// How should ping message timestamp be formatted? ('s' => seconds, 'ms' => milli seconds, 'ns' => nano seconds)
-	PingTimestampFormat string
+	PingTimestampPrecision string
 }
 
 // NewConfig builds a new config
 func NewConfig() Config {
-	return Config{PingInterval: 3, StatsRefreshInterval: 5, HubGopoolSize: 16, PingTimestampFormat: "s"}
+	return Config{PingInterval: 3, StatsRefreshInterval: 5, HubGopoolSize: 16, PingTimestampPrecision: "s"}
 }

--- a/node/config.go
+++ b/node/config.go
@@ -8,9 +8,11 @@ type Config struct {
 	StatsRefreshInterval int
 	// The max size of the Go routines pool for hub
 	HubGopoolSize int
+	// How should ping message timestamp be formatted? ('s' => seconds, 'ms' => milli seconds, 'ns' => nano seconds)
+	PingTimestampFormat string
 }
 
 // NewConfig builds a new config
 func NewConfig() Config {
-	return Config{PingInterval: 3, StatsRefreshInterval: 5, HubGopoolSize: 16}
+	return Config{PingInterval: 3, StatsRefreshInterval: 5, HubGopoolSize: 16, PingTimestampFormat: "s"}
 }

--- a/node/session.go
+++ b/node/session.go
@@ -274,7 +274,7 @@ func (s *Session) addPing() {
 	s.pingTimer = time.AfterFunc(s.pingInterval, s.sendPing)
 }
 
-func newPingMessage(format string) []byte {
+func newPingMessage(format string) *common.PingMessage {
 	var ts int64
 
 	switch format {


### PR DESCRIPTION
### What is the purpose of this pull request?
The anycable-go service sends the ping messages on websocket connections. The message itself is a unix timestamp in seconds. We want to use this timestamp information to calculate the perceived latency of the messages from client's perspective. However the timestamps in seconds do not provide the precision we need. The timestamps in milliseconds is more desirable. To make the change to milli seconds backward compatible, allow ping timestamp format to be configurable.

### What changes did you make? (overview)
Added ping_timestamp_format config which takes the values of "ms" (milli seconds), "ns" (nano seconds) and "s" (seconds) with default "s". Based on the config specified, the ping messages will emit timestamps in milli seconds, nano seconds or seconds. 

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation
