### PR TITLE
Origin check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Add `--allowed_origins` option to enable Origin check during the WebSocket upgrade. ([@skryukov][])
 - Renamed `metrics_log_interval` to `metrics_rotate_interval`. ([@palkan][])
 
 ## 1.1.0.rc1 (2021-05-12)
@@ -122,3 +123,4 @@ See [Changelog](https://github.com/anycable/anycable-go/blob/0-6-stable/CHANGELO
 [@rolandg]: https://github.com/rolandg
 [@gr8bit]: https://github.com/gr8bit
 [@prburgu]: https://github.com/prburgu
+[@skryukov]: https://github.com/skryukov

--- a/cli/options.go
+++ b/cli/options.go
@@ -72,6 +72,7 @@ func init() {
 	fs.IntVar(&defaults.WS.WriteBufferSize, "write_buffer_size", 1024, "")
 	fs.Int64Var(&defaults.WS.MaxMessageSize, "max_message_size", 65536, "")
 	fs.BoolVar(&defaults.WS.EnableCompression, "enable_ws_compression", false, "")
+	fs.StringVar(&defaults.WS.AllowedOrigins, "allowed_origins", "", "")
 
 	fs.IntVar(&defaults.DisconnectQueue.Rate, "disconnect_rate", 100, "")
 	fs.IntVar(&defaults.DisconnectQueue.ShutdownTimeout, "disconnect_timeout", 5, "")
@@ -175,6 +176,7 @@ OPTIONS
   --max_message_size                     Maximum size of a message in bytes, default: 65536, env: ANYCABLE_MAX_MESSAGE_SIZE
   --enable_ws_compression                Enable experimental WebSocket per message compression, default: false, env: ANYCABLE_ENABLE_WS_COMPRESSION
   --hub_gopool_size                      The size of the goroutines pool to broadcast messages, default: 16, env: ANYCABLE_HUB_GOPOOL_SIZE
+  --allowed_origins                      Accept requests only from specified origins, e.g., "www.example.com,*example.io". No check is performed if empty, default: "", env: ANYCABLE_ALLOWED_ORIGINS
 
   --ping_interval                        Action Cable ping interval (in seconds), default: 3, env: ANYCABLE_PING_INTERVAL
   --ping_timestamp_precision             Precision for timestamps in ping messages (s, ms, ns), default: s, env: ANYCABLE_PING_TIMESTAMP_PRECISION

--- a/ws/config.go
+++ b/ws/config.go
@@ -6,6 +6,7 @@ type Config struct {
 	WriteBufferSize   int
 	MaxMessageSize    int64
 	EnableCompression bool
+	AllowedOrigins    string
 }
 
 // NewConfig build a new Config struct

--- a/ws/handler_test.go
+++ b/ws/handler_test.go
@@ -49,3 +49,42 @@ func TestFetchHeaders(t *testing.T) {
 		assert.Equal(t, "192.0.2.1", headers["REMOTE_ADDR"])
 	})
 }
+
+func TestCheckOriginWithoutHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+
+	allowedOrigins := ""
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	allowedOrigins = "secure.origin"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), false)
+}
+
+func TestCheckOrigin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "http://my.localhost:8080")
+
+	allowedOrigins := ""
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	allowedOrigins = "my.localhost:8080"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	allowedOrigins = "MY.localhost:8080"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	allowedOrigins = "localhost:8080"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), false)
+
+	allowedOrigins = "*.localhost:8080"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	allowedOrigins = "secure.origin,my.localhost:8080"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	allowedOrigins = "secure.origin,*.localhost:8080"
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+
+	req.Header.Set("Origin", "http://MY.localhost:8080")
+	assert.Equal(t, CheckOrigin(allowedOrigins)(req), true)
+}


### PR DESCRIPTION
Adds `--allowed_origins` option to enable Origin check during the WebSocket upgrade.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation

Closes #134