### PR TITLE
Add --rpc_enable_tls option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Added `--rpc_enable_tls` option. ([@ryansch][])
+
 - Do not treat RPC failures as errors. ([@palkan][])
 
 Failure (e.g., subscription rejection) is an expected application behaviour and

--- a/cli/options.go
+++ b/cli/options.go
@@ -67,6 +67,7 @@ func init() {
 
 	fs.StringVar(&defaults.RPC.Host, "rpc_host", "localhost:50051", "")
 	fs.IntVar(&defaults.RPC.Concurrency, "rpc_concurrency", 28, "")
+	fs.BoolVar(&defaults.RPC.EnableTLS, "rpc_enable_tls", false, "")
 	fs.StringVar(&headers, "headers", "cookie", "")
 
 	fs.IntVar(&defaults.WS.ReadBufferSize, "read_buffer_size", 1024, "")
@@ -155,6 +156,7 @@ OPTIONS
 
   --rpc_host                             RPC service address, default: localhost:50051, env: ANYCABLE_RPC_HOST
   --rpc_concurrency                      Max number of concurrent RPC request; should be slightly less than the RPC server concurrency, default: 28, env: ANYCABLE_RPC_CONCURRENCY
+  --rpc_enable_tls                       Enable client-side TLS with the RPC server, default: false, env: ANYCABLE_RPC_ENABLE_TLS
   --headers                              List of headers to proxy to RPC, default: cookie, env: ANYCABLE_HEADERS
 
   --disconnect_rate                      Max number of Disconnect calls per second, default: 100, env: ANYCABLE_DISCONNECT_RATE

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,13 +75,15 @@ anycable-go --port=443 -ssl_cert=path/to/ssl.cert -ssl_key=path/to/ssl.key
 => INFO time context=http Starting HTTPS server at 0.0.0.0:443
 ```
 
+If your RPC server requires TLS you can enable it via `--rpc_enable_tls` (`ANYCABLE_RPC_ENABLE_TLS`).
+
 ## Concurrency settings
 
 AnyCable-Go uses a single Go gRPC client to communicate with AnyCable RPC servers (see [the corresponding PR](https://github.com/anycable/anycable-go/pull/88)). We limit the number of concurrent RPC calls to avoid flooding servers (and getting `ResourceExhausted` exceptions in response).
 
 By default, the concurrency limit is equal to **28**, which is intentionally less than the default RPC size (see [Ruby configuration](../ruby/configuration.md#concurrency-settings)): there is a tiny lag between the times when the response is received by the client and the corresponding worker is returned to the pool. Thus, whenever you update the concurrency settings, make sure that the AnyCable-Go value is _slightly less_ than the AnyCable-RPC one.
 
-You can change this value via `--rcp_concurrency` (`ANYCABLE_RPC_CONCURRENCY`) parameter.
+You can change this value via `--rpc_concurrency` (`ANYCABLE_RPC_CONCURRENCY`) parameter.
 
 ## Disconnect events settings
 

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -8,9 +8,11 @@ type Config struct {
 	// Should be slightly less than the RPC server concurrency to avoid
 	// ResourceExhausted errors
 	Concurrency int
+	// Enable client-side TLS on RPC connections?
+	EnableTLS bool
 }
 
 // NewConfig builds a new config
 func NewConfig() Config {
-	return Config{Concurrency: 28}
+	return Config{Concurrency: 28, EnableTLS: false}
 }


### PR DESCRIPTION
This allows anycable to be used with AWS ALB which requires HTTPS when
proxying gRPC.

### What is the purpose of this pull request?
I'm using a private ALB inside of an AWS VPC to proxy the gRPC traffic from websocket containers to anycable-rails containers. ALB doesn't allow the use of h2c and requires an HTTPS listener to be set up.

### What changes did you make? (overview)
I've added a new configuration option named `--rpc_enable_tls` and modified the rpc initialization log message to notify the operator of the selected mode.

### Is there anything you'd like reviewers to focus on?
I wasn't sure what tests to add for testing TLS and cleartext traffic. I've bench tested both settings.

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation

I've tested these changes in our staging environment with: https://github.com/outstand/docker-anycable-go