### PR TITLE
Fix defer Redis Connection Close before checking sentinel role

### DIFF
--- a/pubsub/redis.go
+++ b/pubsub/redis.go
@@ -196,13 +196,13 @@ func (s *RedisSubscriber) listen() error {
 		return err
 	}
 
+	defer c.Close()
+
 	if s.sentinels != "" {
 		if !sentinel.TestRole(c, "master") {
 			return errors.New("Failed master role check")
 		}
 	}
-
-	defer c.Close()
 
 	psc := redis.PubSubConn{Conn: c}
 	if err = psc.Subscribe(s.channel); err != nil {


### PR DESCRIPTION
### What is the purpose of this pull request?

As a result of reviewing the code, I found a place with potential leaked connections to Redis, in a situation where the role is not correctly set for sentinel. As you can see connections will be lost as a result of reconnects until the GC comes back on or the application is quit.

I have not reproduced this situation as I am currently limited in time. But I think that it is possible to draw such a situation in mind and to draw the conclusions that I came to.

### What changes did you make? (overview)

As a fix, I moved the delayed closing of the connection before checking the sentinel role, this ensures that after exit the connection will be closed.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation
