### PR TITLE
Validate Redis server TLS certificates by default, allow to disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Validate Redis TLS connections by default. ([@Envek][])
+
+- Add `redis_tls_verify` setting to disable validation of Redis server TLS certificate. ([@Envek][])
+
 ## 1.2.2 (2022-08-10)
 
 - Add NATS pub/sub adapter. ([@palkan][])
@@ -176,3 +180,4 @@ See [Changelog](https://github.com/anycable/anycable-go/blob/0-6-stable/CHANGELO
 [@prburgu]: https://github.com/prburgu
 [@skryukov]: https://github.com/skryukov
 [@ryansch]: https://github.com/ryansch
+[@Envek]: https://github.com/Envek

--- a/cli/options.go
+++ b/cli/options.go
@@ -234,6 +234,13 @@ func redisCLIFlags(c *config.Config) []cli.Flag {
 			Value:       c.Redis.KeepalivePingInterval,
 			Destination: &c.Redis.KeepalivePingInterval,
 		},
+
+		&cli.BoolFlag{
+			Name:        "redis_tls_verify",
+			Usage:       "Verify Redis server TLS certificate (only if URL protocol is rediss://)",
+			Value:       c.Redis.TLSVerify,
+			Destination: &c.Redis.TLSVerify,
+		},
 	})
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Skipping certificate validation for encrypted connection to Redis is not secure as it allows for man-in-the-middle attack.

However, given how troublesome it may be to set up SSL certificates properly, sometimes it should be disabled. Hence a setting for this.

### What changes did you make? (overview)

 - Changed default behavior from “not validate” to “validate” TLS certificate
 - Added a setting to disable validation (`--redis_tls_verify` or `ANYCABLE_REDIS_TLS_VERIFY`)

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation
