### PR TITLE
Add datadog instrumentation

### DIFF
--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -184,6 +184,9 @@ anycable_go.disconnect_queue_size
 
 All you need is install [Datadog Agent v6+](https://docs.datadoghq.com/agent) only.
 
+See:
+  * [AnyCable + Datadog + Heroku](https://docs.anycable.io/deployment/heroku?id=datadog)
+
 ## Default metrics tags
 
 You can define global tags (added to every reported metric by default) for Prometheus (reported as labels)

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -178,7 +178,7 @@ anycable_go.disconnect_queue_size
 
 ### Datadog
 
-
+All you need is install [Datadog Agent v6+](https://docs.datadoghq.com/agent) only.
 
 ## Default metrics tags
 

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -48,6 +48,10 @@ During the normal operation, the value should be close to zero most of the a tim
 
 The `goroutines_num` metrics is meant for debugging Go routines leak purposes. The number should be O(N), where N is the `clients_num` value for the OSS version and should be O(1) for the PRO version (unless IO polling is disabled).
 
+### `mem_sys_bytes`
+
+The total bytes of memory obtained from the OS (according to [`runtime.MemStats.Sys`](https://golang.org/pkg/runtime/#MemStats)).
+
 ## Prometheus
 
 To enable a HTTP endpoint to serve [Prometheus](https://prometheus.io)-compatible metrics (disabled by default) you must specify `--metrics_http` option (e.g. `--metrics_http="/metrics"`).
@@ -145,7 +149,7 @@ Metrics are pushed with the `anycable_go.` prefix by default. You can override i
 ```sh
 # HELP anycable_go_clients_num The number of active clients
 # TYPE anycable_go_clients_num gauge
-anycable_go.clients_num 0
+anycable_go.clients_num
 
 # HELP anycable_go.mem_sys_bytes The total bytes of memory obtained from the OS
 # TYPE anycable_go.mem_sys_bytes gauge

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -142,6 +142,44 @@ anycable-go --statsd_host=localhost:8125
 
 Metrics are pushed with the `anycable_go.` prefix by default. You can override it by specifying the `statsd_prefix` parameter.
 
+```sh
+# HELP anycable_go_clients_num The number of active clients
+# TYPE anycable_go_clients_num gauge
+anycable_go.clients_num 0
+
+# HELP anycable_go.mem_sys_bytes The total bytes of memory obtained from the OS
+# TYPE anycable_go.mem_sys_bytes gauge
+anycable_go.mem_sys_bytes
+
+# HELP anycable_go.goroutines_num The number of Go routines
+# TYPE anycable_go.goroutines_num gauge
+anycable_go.goroutines_num
+
+# HELP anycable_go.rpc_pending_num The number of pending RPC calls
+# TYPE anycable_go.rpc_pending_num gauge
+anycable_go.rpc_pending_num
+
+# HELP anycable_go.clients_uniq_num The number of unique clients (with respect to connection identifiers)
+# TYPE anycable_go.clients_uniq_num gauge
+anycable_go.clients_uniq_num
+
+# HELP anycable_go.grpc_active_conn_num The number of active gRPC connections are established
+# TYPE anycable_go.grpc_active_conn_num gauge
+anycable_go.grpc_active_conn_num
+
+# HELP anycable_go.broadcast_streams_num The number of active broadcasting streams
+# TYPE anycable_go_broadcast_streams_num gauge
+anycable_go.broadcast_streams_num
+
+# HELP anycable_go.disconnect_queue_size The size of delayed disconnect
+# TYPE anycable_go.disconnect_queue_size gauge
+anycable_go.disconnect_queue_size
+```
+
+### Datadog
+
+
+
 ## Default metrics tags
 
 You can define global tags (added to every reported metric by default) for Prometheus (reported as labels)

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -137,7 +137,7 @@ AnyCable also supports emitting real-time metrics to [StatsD](https://github.com
 For that, you must specify the StatsD server UDP host:
 
 ```sh
-anycable-go -statsd_host=localhost:8125
+anycable-go --statsd_host=localhost:8125
 ```
 
 Metrics are pushed with the `anycable_go.` prefix by default. You can override it by specifying the `statsd_prefix` parameter.

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -185,7 +185,8 @@ anycable_go.disconnect_queue_size
 All you need is install [Datadog Agent v6+](https://docs.datadoghq.com/agent) only.
 
 See:
-  * [AnyCable + Datadog + Heroku](https://docs.anycable.io/deployment/heroku?id=datadog)
+
+* [AnyCable + Datadog + Heroku](https://docs.anycable.io/deployment/heroku?id=datadog)
 
 ## Default metrics tags
 


### PR DESCRIPTION
### What is the purpose of this pull request?

AnyCable has provided StatsD in an open-source version since 1.3. Here are docs about Datadog

### What changes did you make?

* Fixed typo in StatsD section
* Copied explanation of `mem_sys_bytes` metric to the main docs
* Added the list of metrics that AnyCable sends by default via StatsD
* Added the short description and the link to Datadog + Heroku page

### Checklist

- [x] I've updated the documentation