### PR TITLE
docs: add statsd metrics and more metrics descriptions

### DIFF
--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -48,6 +48,14 @@ During the normal operation, the value should be close to zero most of the a tim
 
 The `goroutines_num` metrics is meant for debugging Go routines leak purposes. The number should be O(N), where N is the `clients_num` value for the OSS version and should be O(1) for the PRO version (unless IO polling is disabled).
 
+### `mem_sys_bytes`
+
+The total bytes of memory obtained from the OS (according to [`runtime.MemStats.Sys`](https://golang.org/pkg/runtime/#MemStats)).
+
+### `grpc_active_conn_num`
+
+The number of active gRPC connections are established.
+
 ## Prometheus
 
 To enable a HTTP endpoint to serve [Prometheus](https://prometheus.io)-compatible metrics (disabled by default) you must specify `--metrics_http` option (e.g. `--metrics_http="/metrics"`).
@@ -140,7 +148,25 @@ For that, you must specify the StatsD server UDP host:
 anycable-go -statsd_host=localhost:8125
 ```
 
-Metrics are pushed with the `anycable_go.` prefix by default. You can override it by specifying the `statsd_prefix` parameter.
+Metrics are pushed with the `anycable_go.` prefix by default. You can override it by specifying the `statsd_prefix` parameter. All metrics AnyCable sends via StatsD have `gauge` type. Find more info about StatsD metric types [here](https://github.com/statsd/statsd/blob/master/docs/metric_types.md).
+
+```sh
+anycable_go.broadcast_streams_num:0|g
+
+anycable_go.disconnect_queue_size:0|g
+
+anycable_go.rpc_pending_num:0|g
+
+anycable_go.grpc_active_conn_num:0|g
+
+anycable_go.goroutines_num:18|g
+
+anycable_go.mem_sys_bytes:20428040|g
+
+anycable_go.clients_num:0|g
+
+anycable_go.clients_uniq_num:0|g
+```
 
 ## Default metrics tags
 


### PR DESCRIPTION
### What is the purpose of this pull request?

AnyCable has provided StatsD in an open-source version since 1.3. Here are docs about Datadog

### What changes did you make?

* Copied explanation of `mem_sys_bytes` and `grpc_active_conn_num` metrics to the main docs
* Added the list of metrics that AnyCable sends by default via StatsD

### Checklist

- [x] I've updated the documentation