### PR TITLE
Redis X broadcaster

### DIFF
--- a/.circleci/Gemfile
+++ b/.circleci/Gemfile
@@ -6,6 +6,7 @@ gem "colorize"
 
 if File.directory?(File.join(__dir__, "../../anycable"))
   $stdout.puts "\n=== Using local gems for Anyt ===\n\n"
+  gem "debug"
   gem "anycable", path: "../../anycable"
   gem "anycable-rails", path: "../../anycable-rails"
   gem "anyt", path: "../../anyt"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.19.x
-    - run: make lint
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
       REDIS_URL: redis://localhost:6379/
     services:
       redis:
-        image: redis:6.0-alpine
+        image: redis:6.2-alpine
         ports: ["6379:6379"]
         options: --health-cmd="redis-cli ping" --health-interval 1s --health-timeout 3s --health-retries 30
       nats:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,9 +119,9 @@ jobs:
           - test-conformance-nats
           - test-conformance-nats-embedded
           - test-conformance-ssl
-          - test-conformance-http-broker
-          - test-conformance-broker-redis-pubsub
-          - test-conformance-broker-nats-pubsub
+          - test-conformance-broker-http
+          - test-conformance-broker-redis
+          - test-conformance-broker-nats
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `redisx` broadcast adapter. ([@palkan][])
+
 - Set HTTP broadcast to `$PORT` on Heroku by default. ([@palkan][])
 
 - Add `try-broker` preset to configure required components to use an in-memory broker. ([@palkan][])

--- a/Makefile
+++ b/Makefile
@@ -132,13 +132,13 @@ test-conformance-nats: tmp/anycable-go-test
 test-conformance-nats-embedded: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile ANYCABLE_BROADCAST_ADAPTER=nats ANYCABLE_NATS_SERVERS=nats://127.0.0.1:4242 ANYCABLE_EMBED_NATS=true ANYCABLE_ENATS_ADDR=nats://127.0.0.1:4242 bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable"
 
-test-conformance-http-broker: tmp/anycable-go-test
+test-conformance-broker-http: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile ANYCABLE_BROKER=memory ANYCABLE_BROADCAST_ADAPTER=http ANYCABLE_HTTP_BROADCAST_SECRET=any_secret bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable" --require=etc/anyt/broker_tests/*.rb
 
-test-conformance-broker-redis-pubsub: tmp/anycable-go-test
-	BUNDLE_GEMFILE=.circleci/Gemfile ANYCABLE_BROKER=memory ANYCABLE_BROADCAST_ADAPTER=http ANYCABLE_HTTP_BROADCAST_SECRET=any_secret ANYCABLE_PUBSUB=redis bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable" --require=etc/anyt/broker_tests/*.rb
+test-conformance-broker-redis: tmp/anycable-go-test
+	BUNDLE_GEMFILE=.circleci/Gemfile ANYCABLE_BROKER=memory ANYCABLE_BROADCAST_ADAPTER=redisx ANYCABLE_HTTP_BROADCAST_SECRET=any_secret ANYCABLE_PUBSUB=redis bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable" --require=etc/anyt/broker_tests/*.rb
 
-test-conformance-broker-nats-pubsub: tmp/anycable-go-test
+test-conformance-broker-nats: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile ANYCABLE_BROKER=memory ANYCABLE_EMBED_NATS=true ANYCABLE_ENATS_ADDR=nats://127.0.0.1:4343 ANYCABLE_PUBSUB=nats ANYCABLE_BROADCAST_ADAPTER=http ANYCABLE_HTTP_BROADCAST_SECRET=any_secret bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable" --require=etc/anyt/broker_tests/*.rb
 
 test-conformance-all: test-conformance test-conformance-ssl test-conformance-http

--- a/broadcast/http.go
+++ b/broadcast/http.go
@@ -33,7 +33,7 @@ func NewHTTPConfig() HTTPConfig {
 	}
 }
 
-// HTTPBroadcaster represents HTTP pub/sub
+// HTTPBroadcaster represents HTTP broadcaster
 type HTTPBroadcaster struct {
 	port       int
 	path       string

--- a/broadcast/legacy_redis.go
+++ b/broadcast/legacy_redis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/url"
 	"strings"
 	"time"
@@ -245,9 +244,4 @@ loop:
 
 	psc.Unsubscribe() //nolint:errcheck
 	return <-done
-}
-
-func nextRetry(step int) time.Duration {
-	secs := (step * step) + (rand.Intn(step*4) * (step + 1)) // #nosec
-	return time.Duration(secs) * time.Second
 }

--- a/broadcast/redis.go
+++ b/broadcast/redis.go
@@ -1,0 +1,314 @@
+package broadcast
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	rconfig "github.com/anycable/anycable-go/redis"
+
+	"github.com/apex/log"
+	nanoid "github.com/matoous/go-nanoid"
+	"github.com/rueian/rueidis"
+)
+
+// RedisBroadcaster represents Redis broadcaster using Redis streams
+type RedisBroadcaster struct {
+	node   Handler
+	config *rconfig.RedisConfig
+
+	// Unique consumer identifier
+	consumerName string
+
+	client        rueidis.Client
+	clientOptions *rueidis.ClientOption
+	clientMu      sync.RWMutex
+
+	reconnectAttempt int
+
+	shutdownCh chan struct{}
+	finishedCh chan struct{}
+
+	log *log.Entry
+}
+
+var _ Broadcaster = (*RedisBroadcaster)(nil)
+
+// NewRedisBroadcaster builds a new RedisSubscriber struct
+func NewRedisBroadcaster(node Handler, config *rconfig.RedisConfig) *RedisBroadcaster {
+	name, _ := nanoid.Nanoid(6)
+
+	return &RedisBroadcaster{
+		node:         node,
+		config:       config,
+		consumerName: name,
+		log:          log.WithFields(log.Fields{"context": "broadcast", "provider": "redisx", "id": name}),
+		shutdownCh:   make(chan struct{}),
+		finishedCh:   make(chan struct{}),
+	}
+}
+
+func (s *RedisBroadcaster) IsFanout() bool {
+	return false
+}
+
+func (s *RedisBroadcaster) Start(done chan error) error {
+	options, err := s.config.ToRueidisOptions()
+
+	if err != nil {
+		return err
+	}
+
+	if s.config.IsSentinel() { //nolint:gocritic
+		s.log.WithField("stream", s.config.Channel).WithField("consumer", s.consumerName).Infof("Starting Redis broadcaster at %v (sentinels)", s.config.SentinelHostnames())
+	} else if s.config.IsCluster() {
+		s.log.WithField("stream", s.config.Channel).WithField("consumer", s.consumerName).Infof("Starting Redis broadcaster at %v (cluster)", s.config.Hostnames())
+	} else {
+		s.log.WithField("stream", s.config.Channel).WithField("consumer", s.consumerName).Infof("Starting Redis broadcaster at %s", s.config.Hostname())
+	}
+
+	s.clientOptions = options
+
+	go s.runReader(done)
+
+	return nil
+}
+
+func (s *RedisBroadcaster) Shutdown() error {
+	s.clientMu.RLock()
+	defer s.clientMu.RUnlock()
+
+	if s.client == nil {
+		return nil
+	}
+
+	s.log.Debugf("Shutting down Redis broadcaster")
+
+	close(s.shutdownCh)
+
+	<-s.finishedCh
+
+	res := s.client.Do(
+		context.Background(),
+		s.client.B().XgroupDelconsumer().Key(s.config.Channel).Groupname(s.config.Group).Consumername(s.consumerName).Build(),
+	)
+
+	err := res.Error()
+
+	if err != nil {
+		s.log.Errorf("Failed to remove Redis stream consumer: %v", err)
+	}
+
+	s.client.Close()
+
+	return nil
+}
+
+func (s *RedisBroadcaster) initClient() error {
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
+
+	if s.client != nil {
+		return nil
+	}
+
+	c, err := rueidis.NewClient(*s.clientOptions)
+
+	if err != nil {
+		return err
+	}
+
+	s.client = c
+
+	return nil
+}
+
+func (s *RedisBroadcaster) runReader(done chan (error)) {
+	err := s.initClient()
+
+	if err != nil {
+		s.log.Errorf("Failed to connect to Redis: %v", err)
+		s.maybeReconnect(done)
+		return
+	}
+
+	// First, create a consumer group for the stream
+	res := s.client.Do(context.Background(),
+		s.client.B().XgroupCreate().Key(s.config.Channel).Groupname(s.config.Group).Id("$").Mkstream().Build(),
+	)
+
+	if res.Error() != nil {
+		redisErr := res.RedisError()
+
+		if redisErr != nil {
+			if strings.HasPrefix(redisErr.Error(), "BUSYGROUP") {
+				s.log.Debugf("Redis consumer group already exists")
+			} else {
+				s.log.Errorf("Failed to create consumer group: %v", res.RedisError())
+				s.maybeReconnect(done)
+				return
+			}
+		}
+	}
+
+	s.reconnectAttempt = 0
+
+	readBlockMilliseconds := s.config.StreamReadBlockMilliseconds
+	var lastClaimedAt int64
+
+	for {
+		select {
+		case <-s.shutdownCh:
+			s.log.Debugf("Stop consuming stream")
+			close(s.finishedCh)
+			return
+		default:
+			if lastClaimedAt+readBlockMilliseconds < time.Now().UnixMilli() {
+				reclaimed, err := s.autoclaimMessages(readBlockMilliseconds)
+
+				if err != nil {
+					s.log.Errorf("Failed to claim from Redis stream: %v", err)
+					s.maybeReconnect(done)
+					return
+				}
+
+				lastClaimedAt = time.Now().UnixMilli()
+
+				if len(reclaimed) > 0 {
+					s.log.Debugf("Reclaimed messages: %d", len(reclaimed))
+
+					s.broadcastXrange(reclaimed)
+				}
+			}
+
+			messages, err := s.readFromStream(readBlockMilliseconds)
+
+			if err != nil {
+				s.log.Errorf("Failed to read from Redis stream: %v", err)
+				s.maybeReconnect(done)
+				return
+			}
+
+			if messages != nil {
+				s.broadcastXrange(messages)
+			}
+		}
+	}
+}
+
+func (s *RedisBroadcaster) readFromStream(blockTime int64) ([]rueidis.XRangeEntry, error) {
+	streamRes := s.client.Do(context.Background(),
+		s.client.B().Xreadgroup().Group(s.config.Group, s.consumerName).Block(blockTime).Streams().Key(s.config.Channel).Id(">").Build(),
+	)
+
+	res, _ := streamRes.AsXRead()
+	err := streamRes.Error()
+
+	if err != nil && !rueidis.IsRedisNil(err) {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, nil
+	}
+
+	if messages, ok := res[s.config.Channel]; ok {
+		return messages, nil
+	}
+
+	return nil, nil
+}
+
+func (s *RedisBroadcaster) autoclaimMessages(blockTime int64) ([]rueidis.XRangeEntry, error) {
+	claimRes := s.client.Do(context.Background(),
+		s.client.B().Xautoclaim().Key(s.config.Channel).Group(s.config.Group).Consumer(s.consumerName).MinIdleTime(fmt.Sprintf("%d", blockTime)).Start("0-0").Build(),
+	)
+
+	arr, err := claimRes.ToArray()
+
+	if err != nil && !rueidis.IsRedisNil(err) {
+		return nil, err
+	}
+
+	if arr == nil {
+		return nil, nil
+	}
+
+	if len(arr) < 2 {
+		return nil, fmt.Errorf("autoclaim failed: got %d elements, wanted 2", len(arr))
+	}
+
+	ranges, err := arr[1].AsXRange()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ranges, nil
+}
+
+func (s *RedisBroadcaster) broadcastXrange(messages []rueidis.XRangeEntry) {
+	for _, message := range messages {
+		if payload, pok := message.FieldValues["payload"]; pok {
+			s.log.Debugf("Incoming broadcast: %v", payload)
+
+			s.node.HandleBroadcast([]byte(payload))
+
+			ackRes := s.client.DoMulti(context.Background(),
+				s.client.B().Xack().Key(s.config.Channel).Group(s.config.Group).Id(message.ID).Build(),
+				s.client.B().Xdel().Key(s.config.Channel).Id(message.ID).Build(),
+			)
+
+			err := ackRes[0].Error()
+
+			if err != nil {
+				s.log.Errorf("Failed to ack message: %v", err)
+			}
+		}
+	}
+}
+
+func (s *RedisBroadcaster) maybeReconnect(done chan (error)) {
+	if s.reconnectAttempt >= s.config.MaxReconnectAttempts {
+		close(s.finishedCh)
+		done <- errors.New("failed to reconnect to Redis: attempts exceeded") //nolint:stylecheck
+		return
+	}
+
+	s.reconnectAttempt++
+
+	delay := nextRetry(s.reconnectAttempt - 1)
+
+	s.log.Infof("Next Redis reconnect attempt in %s", delay)
+	time.Sleep(delay)
+
+	s.log.Infof("Reconnecting to Redis...")
+
+	s.clientMu.Lock()
+
+	if s.client != nil {
+		s.client.Close()
+		s.client = nil
+	}
+
+	s.clientMu.Unlock()
+
+	go s.runReader(done)
+}
+
+func nextRetry(step int) time.Duration {
+	if step == 0 {
+		return 250 * time.Millisecond
+	}
+
+	left := math.Pow(2, float64(step))
+	right := 2 * left
+
+	secs := left + (right-left)*rand.Float64() // nolint:gosec
+	return time.Duration(secs) * time.Second
+}

--- a/broadcast/redis_test.go
+++ b/broadcast/redis_test.go
@@ -1,0 +1,281 @@
+package broadcast
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anycable/anycable-go/mocks"
+	rconfig "github.com/anycable/anycable-go/redis"
+	"github.com/anycable/anycable-go/utils"
+	"github.com/rueian/rueidis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	redisAvailable = false
+	redisURL       = os.Getenv("REDIS_URL")
+)
+
+// Check if Redis is available and skip tests otherwise
+func init() {
+	config := rconfig.NewRedisConfig()
+
+	if redisURL != "" {
+		config.URL = redisURL
+	}
+
+	config.Parse() // nolint: errcheck
+
+	c, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: config.Hostnames()})
+
+	if err != nil {
+		fmt.Printf("Failed to connect to Redis: %v", err)
+		return
+	}
+
+	err = c.Do(context.Background(), c.B().Arbitrary("PING").Build()).Error()
+
+	redisAvailable = err == nil
+
+	if !redisAvailable {
+		return
+	}
+
+	c.Do(context.Background(), c.B().XgroupDestroy().Key("__anycable__").Groupname("bx").Build())
+}
+
+func TestRedisBroadcaster(t *testing.T) {
+	if !redisAvailable {
+		t.Skip("Skipping Redis tests: no Redis available")
+		return
+	}
+
+	config := rconfig.NewRedisConfig()
+
+	if redisURL != "" {
+		config.URL = redisURL
+	}
+
+	config.StreamReadBlockMilliseconds = 500
+
+	handler := &mocks.Handler{}
+	errchan := make(chan error)
+	broadcasts := make(chan map[string]string, 10)
+
+	payload := utils.ToJSON(map[string]string{"stream": "any_test", "data": "123_test"})
+
+	handler.On(
+		"HandleBroadcast",
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		data := args.Get(0).([]byte)
+		var msg map[string]string
+		json.Unmarshal(data, &msg) // nolint: errcheck
+
+		broadcasts <- msg
+	})
+
+	t.Run("Handles broadcasts", func(t *testing.T) {
+		broadcaster := NewRedisBroadcaster(handler, &config)
+
+		err := broadcaster.Start(errchan)
+		require.NoError(t, err)
+
+		defer broadcaster.Shutdown() // nolint:errcheck
+
+		require.NoError(t, broadcaster.initClient())
+
+		require.NoError(t, waitRedisStreamConsumers(broadcaster.client, 1))
+
+		require.NoError(t, publishToRedisStream(broadcaster.client, "__anycable__", string(payload)))
+
+		messages := drainBroadcasts(broadcasts)
+		require.Equalf(t, 1, len(messages), "Expected 1 message, got %d", len(messages))
+
+		msg := messages[0]
+
+		assert.Equal(t, "any_test", msg["stream"])
+		assert.Equal(t, "123_test", msg["data"])
+	})
+
+	t.Run("With multiple subscribers", func(t *testing.T) {
+		broadcaster := NewRedisBroadcaster(handler, &config)
+
+		err := broadcaster.Start(errchan)
+		require.NoError(t, err)
+
+		defer broadcaster.Shutdown() // nolint:errcheck
+
+		require.NoError(t, broadcaster.initClient())
+
+		broadcaster2 := NewRedisBroadcaster(handler, &config)
+		err = broadcaster2.Start(errchan)
+		require.NoError(t, err)
+
+		defer broadcaster2.Shutdown() // nolint:errcheck
+
+		require.NoError(t, waitRedisStreamConsumers(broadcaster.client, 2))
+
+		require.NoError(t, publishToRedisStream(broadcaster.client, "__anycable__",
+			string(utils.ToJSON(map[string]string{"stream": "any_test", "data": "123_test"})),
+		))
+
+		require.NoError(t, publishToRedisStream(broadcaster.client, "__anycable__",
+			string(utils.ToJSON(map[string]string{"stream": "any_test", "data": "124_test"})),
+		))
+
+		require.NoError(t, publishToRedisStream(broadcaster.client, "__anycable__",
+			string(utils.ToJSON(map[string]string{"stream": "any_test", "data": "125_test"})),
+		))
+
+		messages := drainBroadcasts(broadcasts)
+
+		require.Equalf(t, 3, len(messages), "Expected 3 messages, got %d", len(messages))
+	})
+}
+
+func TestRedisBroadcasterAcksClaims(t *testing.T) {
+	if !redisAvailable {
+		t.Skip("Skipping Redis tests: no Redis available")
+		return
+	}
+
+	config := rconfig.NewRedisConfig()
+	// Make it short to avoid sleeping for too long in tests
+	config.StreamReadBlockMilliseconds = 100
+
+	if redisURL != "" {
+		config.URL = redisURL
+	}
+
+	handler := &mocks.Handler{}
+	broadcaster := NewRedisBroadcaster(handler, &config)
+
+	errchan := make(chan error)
+	broadcasts := make(chan string, 10)
+
+	closed := false
+
+	handler.On(
+		"HandleBroadcast",
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		msg := string(args.Get(0).([]byte))
+		broadcasts <- msg
+
+		if msg == "2" && !closed {
+			closed = true
+			// Close the connection to prevent consumer from ack-ing the message
+			broadcaster.client.Close()
+			broadcaster.reconnectAttempt = config.MaxReconnectAttempts + 1
+		}
+	})
+
+	err := broadcaster.Start(errchan)
+	require.NoError(t, err)
+	defer broadcaster.Shutdown() // nolint:errcheck
+
+	require.NoError(t, broadcaster.initClient())
+	require.NoError(t, waitRedisStreamConsumers(broadcaster.client, 1))
+
+	require.NoError(t, publishToRedisStream(broadcaster.client, "__anycable__", "1"))
+	require.NoError(t, publishToRedisStream(broadcaster.client, "__anycable__", "2"))
+
+	broadcaster2 := NewRedisBroadcaster(handler, &config)
+	err = broadcaster2.Start(errchan)
+	require.NoError(t, err)
+	defer broadcaster2.Shutdown() // nolint:errcheck
+
+	require.NoError(t, broadcaster2.initClient())
+	require.NoError(t, waitRedisStreamConsumers(broadcaster2.client, 1))
+
+	// We should wait for at least 2*blockTime to mark older consumer as stale
+	// and claim its messages
+	time.Sleep(300 * time.Millisecond)
+
+	messages := drainBroadcasts(broadcasts)
+	require.Equalf(t, 3, len(messages), "Expected 3 messages, got %d", len(messages))
+
+	assert.Equal(t, "1", messages[0])
+	assert.Equal(t, "2", messages[1])
+	// We haven't acked the last message within the first broadcaster,
+	// so the second one must have picked it up
+	assert.Equal(t, "2", messages[1])
+}
+
+func drainBroadcasts[T any](ch chan T) []T {
+	buffer := make([]T, 0)
+
+out:
+	for {
+		select {
+		case msg := <-ch:
+			buffer = append(buffer, msg)
+		case <-time.After(time.Second):
+			break out
+		}
+	}
+
+	return buffer
+}
+
+func publishToRedisStream(client rueidis.Client, stream string, payload string) error {
+	if client == nil {
+		return errors.New("No Redis client configured")
+	}
+
+	res := client.Do(context.Background(),
+		client.B().Xadd().Key(stream).Id("*").FieldValue().FieldValue("payload", payload).Build(),
+	)
+
+	return res.Error()
+}
+
+func waitRedisStreamConsumers(client rueidis.Client, count int) error {
+	if client == nil {
+		return errors.New("No Redis client configured")
+	}
+
+	attempts := 0
+
+	for {
+		if attempts > 5 {
+			return errors.New("No stream consumer were created")
+		}
+
+		res := client.Do(context.Background(), client.B().Arbitrary("client", "list").Build())
+		clientsStr, err := res.ToString()
+
+		if err == nil {
+			clients := strings.Split(clientsStr, "\n")
+
+			readers := 0
+			for _, clientMsg := range clients {
+				if clientMsg == "" {
+					continue
+				}
+
+				clientCmd := strings.Split(strings.Split(clientMsg, "cmd=")[1], " ")[0]
+
+				if clientCmd == "xreadgroup" {
+					readers++
+				}
+			}
+
+			if readers >= count {
+				return nil
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+		attempts++
+	}
+}

--- a/cli/options.go
+++ b/cli/options.go
@@ -271,7 +271,7 @@ func broadcastCLIFlags(c *config.Config) []cli.Flag {
 	return withDefaults(broadcastCategoryDescription, []cli.Flag{
 		&cli.StringFlag{
 			Name:        "broadcast_adapter",
-			Usage:       "Broadcasting adapter to use (http, redis or nats). You can specify multiple at once via a comma-separated list",
+			Usage:       "Broadcasting adapter to use (http, redisx, redis or nats). You can specify multiple at once via a comma-separated list",
 			Value:       c.BroadcastAdapter,
 			Destination: &c.BroadcastAdapter,
 		},

--- a/cli/runner_options.go
+++ b/cli/runner_options.go
@@ -64,6 +64,9 @@ func WithDefaultBroadcaster() Option {
 			case "redis":
 				rb := broadcast.NewLegacyRedisBroadcaster(h, &c.Redis)
 				broadcasters = append(broadcasters, rb)
+			case "redisx":
+				rb := broadcast.NewRedisBroadcaster(h, &c.Redis)
+				broadcasters = append(broadcasters, rb)
 			case "nats":
 				nb := broadcast.NewLegacyNATSBroadcaster(h, &c.NATS)
 				broadcasters = append(broadcasters, nb)

--- a/docs/broker.md
+++ b/docs/broker.md
@@ -110,7 +110,7 @@ INFO 2023-04-14T00:31:55.548Z context=main Using in-memory broker (epoch: vRXl, 
 ...
 ```
 
-With broker enabled in an AnyCable-Go cluster, you MUST use a non-distributed, single-node broadcaster (currently, only `http`). Otherwise, different nodes will have different IDs for the same messages and using cache will be impossible. See [Broadcast adapters](/ruby/broadcast_adapters.md) for more information.
+With broker enabled in an AnyCable-Go cluster, you MUST use a non-distributed, single-node broadcaster (currently, `http` and `redisx` are available). Otherwise, different nodes will have different IDs for the same messages and using cache will be impossible. See [Broadcast adapters](/ruby/broadcast_adapters.md) for more information.
 
 To re-transmit _registered_ messages within a cluster, you MUST also configure a pub/sub adapter (via the `--pubsub` option). See [Pub/Sub documentation](./pubsub.md) for available options.
 
@@ -155,7 +155,7 @@ To sum up, to enable broker features, you must configure:
 
 - `--broker` option with a broker adapter name
 - `--pubsub` option with a pub/sub adapter name
-- `--broadcaster` option with a compatible broadcasting adapters (currently, only `http`).
+- `--broadcaster` option with a compatible broadcasting adapters (`http` or `redisx`).
 
 ## Configuration
 
@@ -171,11 +171,11 @@ Currently, the configuration is global. We plan to add support for granular (per
 
 ### Memory
 
-The default broker adapter. It stores all data in memory. It can be used for single node installations, and it's a primary option for development and testing purposes.
+The default broker adapter. It stores all data in memory. It can be used **only for single node installations**. So, it's perfect for development and testing as well as applications having just a single WebSocket server.
 
-Since the data is stored in memory, it's getting lost during restarts.
+**IMPORTANT**: Since the data is stored in memory, it's getting lost during restarts.
 
-**NOTE:** Storing data in memory can noticeably increase the overall RAM usage of an AnyCable-Go process.
+**NOTE:** Storing data in memory may result into the increased RAM usage of an AnyCable-Go process.
 
 ### Redis
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ Supports wildcards, e.g., `--allowed_origins=*.evilmartians.io,www.evilmartians.
 
 **--broadcast_adapter** (`ANYCABLE_BROADCAST_ADAPTER`, default: `redis`)
 
-[Broadcasting adapter](../ruby/broadcast_adapters.md) to use. Available options: `redis` (default), `nats`, and `http`.
+[Broadcasting adapter](../ruby/broadcast_adapters.md) to use. Available options: `redis` (default), `redisx`, `nats`, and `http`.
 
 When HTTP adapter is used, AnyCable-Go accepts broadcasting requests on `:8090/_broadcast`.
 
@@ -81,7 +81,7 @@ Redis URL for pub/sub (default: `"redis://localhost:6379/5"`).
 
 **--redis_channel** (`ANYCABLE_REDIS_CHANNEL`)
 
-Redis channel for broadcasting (default: `"__anycable__"`).
+Redis channel for broadcasting (default: `"__anycable__"`). When using the `redisx` adapter, it's used as a name of the Redis stream.
 
 **--nats_servers** (`ANYCABLE_NATS_SERVERS`)
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Introduce a new broadcasting adapter using Redis Streams consumer groups. This adapter is meant to be used with a broker, since every message is processed by a single node from the cluster.

### What changes did you make? (overview)

- [x] Added new broadcast adapter (`broadcast/redis.go`)
- [x] Extracted ruedis configuration into `redis` package.

### Follow-ups?

- Delete stale consumers automatically.

Every time we start a server, we create a new consumer group. On the server shutdown, we destroy the consumer group. However, if the server crashed unexpectedly, the consumer may stay on the list of consumers in Redis. We can implement automatic stale consumers deletion. For example, we can check for the stale consumers (how?) at the server start and destroy them.

- Instrumentation.

It can be useful to track the number of pending messages in the stream. However, this metric is per-cluster, so we need to figure out what's the best way to provide this information.

- Configuration.

Currently, the consumer group name and the timeout to wait for messages (_block time_) are hard-coded. Do we want to make them configurable?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
