### PR TITLE
Disconnect modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Introduce `--disconnect_mode` and deprecate `--disable_disconnect`. ([@palkan][])
+
+You can use `--disconnect_mode=never` to achieve the same behaviour as with `--disable_disconnect`. The new (and default) `--disconnect_mode=auto` automatically detects if a Disconnect call is needed for a session (for example, Hotwire clients don't need it).
+
 - Refactor broadcasting to preserve the order of messages within a single stream. ([@palkan][])
 
 Previously, we used a Go routine pool to concurrently delivery broadcasts, which led to nondeterministic order of messages within a single stream delivered in a short period of time. Now, we preserve the order of messages within a stream—the delivered as they were accepted by the server.

--- a/cli/options.go
+++ b/cli/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/anycable/anycable-go/broker"
 	"github.com/anycable/anycable-go/config"
+	"github.com/anycable/anycable-go/node"
 	"github.com/anycable/anycable-go/version"
 	"github.com/nats-io/nats.go"
 	"github.com/urfave/cli/v2"
@@ -175,6 +176,14 @@ Use metrics_rotate_interval instead.`)
 	// Automatically set the URL of the embedded NATS as the pub/sub server URL
 	if c.EmbedNats && c.NATS.Servers == nats.DefaultURL {
 		c.NATS.Servers = c.EmbeddedNats.ServiceAddr
+	}
+
+	if c.DisconnectorDisabled {
+		fmt.Println(`DEPRECATION WARNING: disable_disconnect option is deprecated
+and will be removed in the next major release of anycable-go.
+Use disconnect_mode=never instead.`)
+
+		c.App.DisconnectMode = node.DISCONNECT_MODE_NEVER
 	}
 
 	return &c, nil, false
@@ -542,6 +551,13 @@ func rpcCLIFlags(c *config.Config, headers, cookieFilter *string) []cli.Flag {
 // rpcCLIFlags returns CLI flags for disconnect options
 func disconnectorCLIFlags(c *config.Config) []cli.Flag {
 	return withDefaults(disconnectorCategoryDescription, []cli.Flag{
+		&cli.StringFlag{
+			Name:        "disconnect_mode",
+			Usage:       "Define when to call Disconnect callback (always, never, auto)",
+			Destination: &c.App.DisconnectMode,
+			Value:       c.App.DisconnectMode,
+		},
+
 		&cli.IntFlag{
 			Name:        "disconnect_rate",
 			Usage:       "Max number of Disconnect calls per second",
@@ -560,6 +576,7 @@ func disconnectorCLIFlags(c *config.Config) []cli.Flag {
 			Name:        "disable_disconnect",
 			Usage:       "Disable calling Disconnect callback",
 			Destination: &c.DisconnectorDisabled,
+			Hidden:      true,
 		},
 	})
 }

--- a/cli/runner_options.go
+++ b/cli/runner_options.go
@@ -24,7 +24,7 @@ func WithName(name string) Option {
 	}
 }
 
-// WithName is an Option to set Runner controller
+// WithController is an Option to set Runner controller
 func WithController(fn controllerFactory) Option {
 	return func(r *Runner) error {
 		if r.controllerFactory != nil {
@@ -40,6 +40,14 @@ func WithDefaultRPCController() Option {
 	return WithController(func(m *metrics.Metrics, c *config.Config) (node.Controller, error) {
 		return rpc.NewController(m, &c.RPC), nil
 	})
+}
+
+// WithDisconnector is a an Option to set Runner disconnector
+func WithDisconnector(fn disconnectorFactory) Option {
+	return func(r *Runner) error {
+		r.disconnectorFactory = fn
+		return nil
+	}
 }
 
 // WithBroadcaster is an Option to set Runner broadaster

--- a/common/common.go
+++ b/common/common.go
@@ -137,12 +137,13 @@ type CallResult struct {
 
 // ConnectResult is a result of initializing a connection (calling a Connect method)
 type ConnectResult struct {
-	Identifier    string
-	Transmissions []string
-	Broadcasts    []*StreamMessage
-	CState        map[string]string
-	IState        map[string]string
-	Status        int
+	Identifier         string
+	Transmissions      []string
+	Broadcasts         []*StreamMessage
+	CState             map[string]string
+	IState             map[string]string
+	DisconnectInterest int
+	Status             int
 }
 
 // ToCallResult returns the corresponding CallResult
@@ -162,15 +163,16 @@ func (c *ConnectResult) ToCallResult() *CallResult {
 // messages to sent and broadcast.
 // It's a communication "protocol" between a node and a controller.
 type CommandResult struct {
-	StopAllStreams bool
-	Disconnect     bool
-	Streams        []string
-	StoppedStreams []string
-	Transmissions  []string
-	Broadcasts     []*StreamMessage
-	CState         map[string]string
-	IState         map[string]string
-	Status         int
+	StopAllStreams     bool
+	Disconnect         bool
+	Streams            []string
+	StoppedStreams     []string
+	Transmissions      []string
+	Broadcasts         []*StreamMessage
+	CState             map[string]string
+	IState             map[string]string
+	DisconnectInterest int
+	Status             int
 }
 
 // ToCallResult returns the corresponding CallResult

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,7 +206,13 @@ The number of seconds to wait before forcefully shutting down a disconnect queue
 
 Thus, the default configuration can handle a backlog of up to 500 calls. By increasing both values, you can reduce the number of lost disconnect notifications.
 
-If your application code doesn't rely on `disconnect` / `unsubscribe` callbacks, you can disable `Disconnect` calls completely (to avoid unnecessary load) by setting `--disable_disconnect` option or `ANYCABLE_DISABLE_DISCONNECT` env var.
+**--disconnect_mode** (`ANYCABLE_DISCONNECT_MODE`)
+
+This parameter defines when a Disconnect call should be made for a session. The default is "auto", which means that the Disconnect call is made only if we detected the client _interest_ in it. Currently, we only skip Disconnect calls for sessions authenticated via [JWT](./jwt_identification.md) and using [signed streams](./signed_streams.md) (Hotwire or CableReady).
+
+Other available modes are "always" and "never". Thus, to disable Disconnect call completely, use `--disconnect_mode=never`.
+
+Using `--disconnect_mode=always` is useful when you have some logic in the `ApplicationCable::Connetion#disconnect` method and you want to invoke it even for JWT and signed streams sessions.
 
 \* It's (almost) impossible to guarantee that `disconnect` callbacks would be called for 100%. There is always a chance of a server crash or `kill -9` or something worse. Consider an alternative approach to tracking client states (see [example](https://github.com/anycable/anycable/issues/99#issuecomment-611998267)).
 

--- a/docs/signed_streams.md
+++ b/docs/signed_streams.md
@@ -1,8 +1,8 @@
 # Speedy Hotwire and CableReady streams
 
-AnyCable provides an ability to terminate Hotwire ([Turbo Streams](https://turbo.hotwired.dev/handbook/streams)) and [CableReady](https://cableready.stimulusreflex.com) (v5+) subscriptions at the WS server without performing RPC calls. Thus, you can make subscriptions blazingly fast and reduce the load on the RPC server.
+AnyCable provides an ability to terminate Hotwire ([Turbo Streams](https://turbo.hotwired.dev/handbook/streams)) and [CableReady](https://cableready.stimulusreflex.com) (v5+) subscriptions at the WS server without _touching_ your Ruby/Rails application (i.e., without performing RPC calls). Thus, you can make subscriptions blazingly fast and reduce the load on the RPC server.
 
-In combination with [JWT identification](./jwt_identification.md), this feature makes it possible to avoid running RPC server at all in case you only need Hotwire/CableReady functionality. **NOTE:** You should also disable disconnect calls (`anycable-go --disable_disconnect` or `ANYCABLE_DISABLE_DISCONNECT=1`).
+In combination with [JWT identification](./jwt_identification.md), this feature makes it possible to avoid running RPC server at all in case you only need Hotwire/CableReady functionality.
 
 > 🎥 Check out this [AnyCasts episode](https://anycable.io/blog/anycasts-rails-7-hotwire-and-anycable/) to learn how to use AnyCable with Hotwire Rails application in a RPC-less way.
 

--- a/features/metrics.testfile
+++ b/features/metrics.testfile
@@ -2,7 +2,7 @@ launch :rpc, "bundle exec anyt --only-rpc"
 wait_tcp 50051
 
 launch :anycable,
-  "./dist/anycable-go --disable_disconnect --metrics_rotate_interval=3 --ping_interval=1 --metrics_log --metrics_log_filter=rpc_call_total,failed_auths_total",
+  "./dist/anycable-go --disconnect_mode=never --metrics_rotate_interval=3 --ping_interval=1 --metrics_log --metrics_log_filter=rpc_call_total,failed_auths_total",
   capture_output: true
 wait_tcp 8080
 

--- a/features/runner.rb
+++ b/features/runner.rb
@@ -4,6 +4,8 @@
 # Only use bundler/inline if gems are not installed yet
 begin
   require "childprocess"
+  require "jwt"
+  require "active_support/message_verifier"
 rescue LoadError
   require "bundler/inline"
 
@@ -11,9 +13,12 @@ rescue LoadError
     source "https://rubygems.org"
 
     gem "childprocess"
+    gem "jwt"
+    gem "activesupport"
   end
 
   require "childprocess"
+  require "active_support/message_verifier"
 end
 
 require "socket"

--- a/features/runner.rb
+++ b/features/runner.rb
@@ -1,29 +1,27 @@
 # frozen_string_literal: true
 
+retried = false
+require "bundler/inline"
 
-# Only use bundler/inline if gems are not installed yet
 begin
-  require "childprocess"
-  require "jwt"
-  require "active_support/message_verifier"
-rescue LoadError
-  require "bundler/inline"
-
-  gemfile(true, quiet: true) do
+  gemfile(retried, quiet: true) do
     source "https://rubygems.org"
 
-    gem "childprocess"
+    gem "childprocess", "~> 4.1"
     gem "jwt"
-    gem "activesupport"
+    gem "activesupport", "~> 7.0"
   end
-
-  require "childprocess"
-  require "active_support/message_verifier"
+rescue
+  raise if retried
+  retried = true
+  retry
 end
 
 require "socket"
 require "time"
 require "json"
+
+require "active_support/message_verifier"
 
 class BenchRunner
   LOG_LEVEL_TO_NUM = {

--- a/features/turbo_rpc_less.testfile
+++ b/features/turbo_rpc_less.testfile
@@ -1,0 +1,61 @@
+launch :anycable,
+  "./dist/anycable-go --turbo_rails_key=s3Krit --jwt_id_key=qwerty " \
+  "--metrics_rotate_interval=1 --metrics_log --metrics_log_filter=rpc_call_total,rpc_error_total,rpc_retries_total",
+  capture_output: true
+
+wait_tcp 8080
+
+payload = {ext: {}.to_json, exp: (Time.now.to_i + 60)}
+
+token = ::JWT.encode(payload, "qwerty", "HS256")
+
+verifier = ActiveSupport::MessageVerifier.new("s3Krit", digest: "SHA256", serializer: JSON)
+signed_stream_name = verifier.generate("chat/2023")
+
+scenario = [
+  {
+    client: {
+      protocol: "action_cable",
+      name: "turbo",
+      connection_options: {
+        query: {
+          jid: token
+        }
+      },
+      actions: [
+        {
+          subscribe: {
+            channel: "Turbo::StreamsChannel",
+            params: {
+              signed_stream_name: signed_stream_name
+            }
+          }
+        },
+      ]
+    }
+  }
+]
+
+TEST_COMMAND = <<~CMD
+  bundle exec wsdirector ws://localhost:8080/cable -i #{scenario.to_json}
+CMD
+
+run :wsdirector, TEST_COMMAND
+
+result = stdout(:wsdirector)
+
+unless result.include?("1 clients, 0 failures")
+  fail "Unexpected scenario result:\n#{result}"
+end
+
+# Wait for metrics to be logged
+sleep 2
+
+stop :anycable
+
+logs = stdout(:anycable)
+
+# We should not see any rpc calls
+if logs =~ /rpc_call_total=[1-9] rpc_error_total=[1-9] rpc_retries_total=[1-9]/
+  fail "Expected metrics logs not found:\n#{logs}"
+end

--- a/hub/gate_test.go
+++ b/hub/gate_test.go
@@ -42,7 +42,7 @@ func TestShutdown(t *testing.T) {
 
 	gate.Broadcast(&common.StreamMessage{Stream: "test", Data: "1"})
 
-	time.Sleep(120 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	gate.Broadcast(&common.StreamMessage{Stream: "test", Data: "2"})
 

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -47,6 +47,12 @@ func (c *IdentifiableController) Authenticate(sid string, env *common.SessionEnv
 		return c.controller.Authenticate(sid, env)
 	}
 
+	if res.CState == nil {
+		res.CState = make(map[string]string)
+	}
+
+	res.DisconnectInterest = -1
+
 	return res, err
 }
 

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -17,9 +17,6 @@ func TestIdentifiableController(t *testing.T) {
 
 	subject := NewIdentifiableController(&controller, &identifier)
 
-	t.Run("Authenticate", func(t *testing.T) {
-	})
-
 	t.Run("Start", func(t *testing.T) {
 		controller.On("Start").Return(nil)
 
@@ -37,7 +34,12 @@ func TestIdentifiableController(t *testing.T) {
 	})
 
 	t.Run("Authenticate (success)", func(t *testing.T) {
-		expected := &common.ConnectResult{Identifier: "test_ids", Transmissions: []string{`{"type":"welcome","sid":"2021"}`}, Status: common.SUCCESS}
+		expected := &common.ConnectResult{
+			Identifier:         "test_ids",
+			Transmissions:      []string{`{"type":"welcome","sid":"2021"}`},
+			DisconnectInterest: -1,
+			Status:             common.SUCCESS,
+		}
 
 		controller.On("Authenticate", "2021", env).Return(nil, errors.New("shouldn't be called"))
 		identifier.On("Identify", "2021", env).Return(expected, nil)
@@ -60,7 +62,6 @@ func TestIdentifiableController(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
 		controller.AssertNotCalled(t, "Authenticate", "2020", env)
-
 	})
 
 	t.Run("Authenticate (error)", func(t *testing.T) {

--- a/node/config.go
+++ b/node/config.go
@@ -1,7 +1,17 @@
 package node
 
+const (
+	DISCONNECT_MODE_ALWAYS = "always"
+	DISCONNECT_MODE_AUTO   = "auto"
+	DISCONNECT_MODE_NEVER  = "never"
+)
+
+var DISCONNECT_MODES = []string{DISCONNECT_MODE_ALWAYS, DISCONNECT_MODE_AUTO, DISCONNECT_MODE_NEVER}
+
 // Config contains general application/node settings
 type Config struct {
+	// Define when to invoke Disconnect callback
+	DisconnectMode string
 	// How often server should send Action Cable ping messages (seconds)
 	PingInterval int
 	// How ofter to refresh node stats (seconds)
@@ -14,5 +24,11 @@ type Config struct {
 
 // NewConfig builds a new config
 func NewConfig() Config {
-	return Config{PingInterval: 3, StatsRefreshInterval: 5, HubGopoolSize: 16, PingTimestampPrecision: "s"}
+	return Config{
+		PingInterval:           3,
+		StatsRefreshInterval:   5,
+		HubGopoolSize:          16,
+		PingTimestampPrecision: "s",
+		DisconnectMode:         DISCONNECT_MODE_AUTO,
+	}
 }

--- a/node/session_test.go
+++ b/node/session_test.go
@@ -227,6 +227,8 @@ func TestCacheEntry(t *testing.T) {
 	session.env.MergeConnectionState(&map[string]string{"tenant": "x", "locale": "it"})
 	session.env.MergeChannelState("chat_1", &map[string]string{"presence": "on"})
 
+	session.MarkDisconnectable(true)
+
 	cached, err := session.ToCacheEntry()
 	require.NoError(t, err)
 
@@ -248,6 +250,8 @@ func TestCacheEntry(t *testing.T) {
 	assert.Equal(t, "x", new_session.env.GetConnectionStateField("tenant"))
 	assert.Equal(t, "it", new_session.env.GetConnectionStateField("locale"))
 	assert.Equal(t, "on", new_session.env.GetChannelStateField("chat_1", "presence"))
+
+	assert.True(t, new_session.IsDisconnectable())
 }
 
 func TestCacheEntryEmptySession(t *testing.T) {
@@ -282,4 +286,20 @@ func TestPrevSid(t *testing.T) {
 
 	session.env = common.NewSessionEnv("http://example.dev/cable?jid=xxxx&sid=213", &headers)
 	assert.Equal(t, "456", session.PrevSid())
+}
+
+func TestMarkDisconnectable(t *testing.T) {
+	session := Session{}
+
+	session.MarkDisconnectable(false)
+
+	assert.False(t, session.IsDisconnectable())
+
+	session.MarkDisconnectable(true)
+
+	assert.True(t, session.IsDisconnectable())
+
+	session.MarkDisconnectable(false)
+
+	assert.True(t, session.IsDisconnectable())
 }

--- a/rails/cable_ready.go
+++ b/rails/cable_ready.go
@@ -61,9 +61,10 @@ func (c *CableReadyController) Subscribe(sid string, env *common.SessionEnv, id 
 	c.log.WithField("identifier", channel).Debugf("verified stream: %s", stream)
 
 	return &common.CommandResult{
-		Status:        common.SUCCESS,
-		Transmissions: []string{common.ConfirmationMessage(channel)},
-		Streams:       []string{stream},
+		Status:             common.SUCCESS,
+		Transmissions:      []string{common.ConfirmationMessage(channel)},
+		Streams:            []string{stream},
+		DisconnectInterest: -1,
 	}, nil
 }
 

--- a/rails/cable_ready_test.go
+++ b/rails/cable_ready_test.go
@@ -28,6 +28,7 @@ func TestCableReadyController(t *testing.T) {
 		require.Equal(t, common.SUCCESS, res.Status)
 		assert.Equal(t, []string{common.ConfirmationMessage(channel)}, res.Transmissions)
 		assert.Equal(t, []string{"stream:2021"}, res.Streams)
+		assert.Equal(t, -1, res.DisconnectInterest)
 	})
 
 	t.Run("Subscribe (failure)", func(t *testing.T) {

--- a/rails/turbo.go
+++ b/rails/turbo.go
@@ -61,9 +61,10 @@ func (c *TurboController) Subscribe(sid string, env *common.SessionEnv, id strin
 	c.log.WithField("identifier", channel).Debugf("verified stream: %s", stream)
 
 	return &common.CommandResult{
-		Status:        common.SUCCESS,
-		Transmissions: []string{common.ConfirmationMessage(channel)},
-		Streams:       []string{stream},
+		Status:             common.SUCCESS,
+		Transmissions:      []string{common.ConfirmationMessage(channel)},
+		Streams:            []string{stream},
+		DisconnectInterest: -1,
 	}, nil
 }
 

--- a/rails/turbo_test.go
+++ b/rails/turbo_test.go
@@ -28,6 +28,7 @@ func TestTurboController(t *testing.T) {
 		require.Equal(t, common.SUCCESS, res.Status)
 		assert.Equal(t, []string{common.ConfirmationMessage(channel)}, res.Transmissions)
 		assert.Equal(t, []string{"chat:2021"}, res.Streams)
+		assert.Equal(t, -1, res.DisconnectInterest)
 	})
 
 	t.Run("Subscribe (failure)", func(t *testing.T) {


### PR DESCRIPTION
### What is the purpose of this pull request?

Introduce disconnect modes, including "auto" mode which determines whether to perform Disconnect RPC calls per session.

### What changes did you make? (overview)

- Added `DisconnectInterest` field to CallResult and CommandResult to indicate whether the client is interested in Disconnect callbacks. Currently, we only use this field in Identify and signed streams controllers, but the functionality can be extended to RPC calls as well.
- Extracted `node.Authenticated` to allow custom applications to register sessions without authenticating via RPC.
- Added `session.MarkDisconnectable(true | false)`.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
