### PR TITLE
Allow to configure secure connection to RPC server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- Allow to configure secure gRPC connection. ([@Envek][])
+
+  Option `--rpc_tls_root_ca` allow to specify private root certificate authority certificate to verify RPC server certificate.
+  Option `--rpc_tls_verify` allow to disable RPC server certificate verification (insecure, use only in test/development).
+
 ## 1.4.0 (2023-07-07)
 
 - Add HTTP RPC implementation. ([@palkan][])

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,11 @@ test-conformance: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token" --target-url="ws://localhost:8080/cable"
 
 test-conformance-ssl: tmp/anycable-go-test
-	BUNDLE_GEMFILE=.circleci/Gemfile bundle exec anyt -c "tmp/anycable-go-test --headers=cookie,x-api-token --ssl_key=etc/ssl/server.key --ssl_cert=etc/ssl/server.crt --port=8443" --target-url="wss://localhost:8443/cable"
+	ANYCABLE_RPC_TLS_CERT=etc/ssl/server.crt \
+	ANYCABLE_RPC_TLS_KEY=etc/ssl/server.key \
+	BUNDLE_GEMFILE=.circleci/Gemfile bundle exec anyt -c \
+	"tmp/anycable-go-test --headers=cookie,x-api-token --rpc_enable_tls --rpc_tls_verify=false --ssl_key=etc/ssl/server.key --ssl_cert=etc/ssl/server.crt --port=8443" \
+	--target-url="wss://localhost:8443/cable"
 
 test-conformance-http: tmp/anycable-go-test
 	BUNDLE_GEMFILE=.circleci/Gemfile \

--- a/cli/options.go
+++ b/cli/options.go
@@ -519,6 +519,19 @@ func rpcCLIFlags(c *config.Config, headers, cookieFilter *string) []cli.Flag {
 			Destination: &c.RPC.EnableTLS,
 		},
 
+		&cli.BoolFlag{
+			Name:        "rpc_tls_verify",
+			Usage:       "Whether to verify the RPC server certificate",
+			Destination: &c.RPC.TLSVerify,
+			Value:       true,
+		},
+
+		&cli.StringFlag{
+			Name:        "rpc_tls_root_ca",
+			Usage:       "CA root certificate file path or contents in PEM format (if not set, system CAs will be used)",
+			Destination: &c.RPC.TLSRootCA,
+		},
+
 		&cli.IntFlag{
 			Name:        "rpc_max_call_recv_size",
 			Usage:       "Override default MaxCallRecvMsgSize for RPC client (bytes)",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,10 @@ anycable-go --port=443 -ssl_cert=path/to/ssl.cert -ssl_key=path/to/ssl.key
 
 If your RPC server requires TLS you can enable it via `--rpc_enable_tls` (`ANYCABLE_RPC_ENABLE_TLS`).
 
+If RPC server uses certificate issued by private CA, then you can pass either its file path or PEM contents with `--rpc_tls_root_ca` (`ANYCABLE_RPC_TLS_ROOT_CA`).
+
+If RPC uses self-signed certificate, you can disable RPC server certificate verification by setting `--rpc_tls_verify` (`ANYCABLE_RPC_TLS_VERIFY`) to `false`, but this is insecure, use only in test/development.
+
 ## Concurrency settings
 
 AnyCable-Go uses a single Go gRPC client\* to communicate with AnyCable RPC servers (see [the corresponding PR](https://github.com/anycable/anycable-go/pull/88)). We limit the number of concurrent RPC calls to avoid flooding servers (and getting `ResourceExhausted` exceptions in response).

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -58,8 +58,14 @@ func NewConfig() Config {
 	return Config{Concurrency: 28, EnableTLS: false, TLSVerify: true, Host: defaultRPCHost, Implementation: "grpc", RequestTimeout: 3000}
 }
 
+// Whether secure connection to RPC server is enabled either explicitly or implicitly
+func (c *Config) TLSEnabled() bool {
+	return c.EnableTLS || c.TLSRootCA != ""
+}
+
+// TLSConfig builds TLS configuration for RPC client
 func (c *Config) TLSConfig() (*tls.Config, error) {
-	if !c.EnableTLS {
+	if !c.TLSEnabled() {
 		return nil, nil
 	}
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -70,8 +70,13 @@ func NewHTTPDialer(c *Config) (Dialer, error) {
 }
 
 func NewHTTPService(c *Config) (*HTTPService, error) {
+	tlsConfig, error := c.TLSConfig()
+	if error != nil {
+		return nil, error
+	}
+
 	client := &http.Client{
-		Transport: &http.Transport{},
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
 	}
 
 	baseURL, err := url.Parse(c.Host)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"math"
@@ -511,9 +510,9 @@ func defaultDialer(conf *Config) (pb.RPCClient, ClientHelper, error) {
 	}
 
 	if enableTLS {
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: false,
-			MinVersion:         tls.VersionTLS12,
+		tlsConfig, error := conf.TLSConfig()
+		if error != nil {
+			return nil, nil, error
 		}
 
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -184,7 +184,7 @@ func NewController(metrics metrics.Instrumenter, config *Config) *Controller {
 // Start initializes RPC connection pool
 func (c *Controller) Start() error {
 	host := c.config.Host
-	enableTLS := c.config.EnableTLS
+	enableTLS := c.config.TLSEnabled()
 	impl := c.config.Implementation
 
 	dialer := c.config.DialFun
@@ -492,7 +492,7 @@ func newContext(sessionID string) context.Context {
 
 func defaultDialer(conf *Config) (pb.RPCClient, ClientHelper, error) {
 	host := conf.Host
-	enableTLS := conf.EnableTLS
+	enableTLS := conf.TLSEnabled()
 
 	kacp := keepalive.ClientParameters{
 		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity


### PR DESCRIPTION
Partially implements #180

### What is the purpose of this pull request?

Allow to explicitly specify root certificate authority certificate to validate connection to gRPC server.

### What changes did you make? (overview)

Config option and loading of certificate from either file or directly from provided string value.

Recommended usage:

 1. Specify CA cert file path in the `rpc_tls_root_ca` command line option:

    ```sh
    anycable-go --rpc_tls_root_ca /path/to/rootCA.pem --rpc_enable_tls true
    ```

 2. Specify CA cert contents directly in the `ANYCABLE_RPC_TLS_ROOT_CA` env variable:

    ```sh
    ANYCABLE_RPC_TLS_ROOT_CA="$(cat /path/to/rootCA.pem)" ./anycable-go --rpc_enable_tls true
    ```

### Is there anything you'd like reviewers to focus on?

Is it a good idea to check for file presence when there is whole few kilobyte long certificate chain presented in a string value?

### Checklist

- [ ] I've added tests for this change (not sure how to test)
- [x] I've added a Changelog entry
- [x] I've updated documentation