### PR TITLE
feat: --shutdown_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `--shutdown_timeout` option to configure graceful shutdown timeout. ([@palkan][])
+
 ## 1.4.1 (2024-07-24)
 
 - Allow to configure secure gRPC connection. ([@Envek][])

--- a/cli/options.go
+++ b/cli/options.go
@@ -255,6 +255,13 @@ func serverCLIFlags(c *config.Config, path *string) []cli.Flag {
 			Usage:       "HTTP health endpoint path",
 			Destination: &c.HealthPath,
 		},
+
+		&cli.IntFlag{
+			Name:        "shutdown_timeout",
+			Usage:       "Graceful shutdown timeout (in seconds)",
+			Value:       c.App.ShutdownTimeout,
+			Destination: &c.App.ShutdownTimeout,
+		},
 	})
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,10 @@ Logging level (default: `"info"`).
 
 Enable debug mode (more verbose logging).
 
+**--shutdown_timeout** (`ANYCABLE_SHUTDOWN_TIMEOUT`)
+
+The number of seconds to wait for the server to shutdown gracefully, i.e., disconnect all active sessions and perform the corresponding Disconnect RPC calls (see below). Default: 30.
+
 ## Presets
 
 AnyCable-Go comes with a few built-in configuration presets for particular deployments environments, such as Heroku or Fly. The presets are detected and activated automatically. As an indication, you can find a line in the logs:
@@ -233,7 +237,7 @@ Other available modes are "always" and "never". Thus, to disable Disconnect call
 
 Using `--disconnect_mode=always` is useful when you have some logic in the `ApplicationCable::Connetion#disconnect` method and you want to invoke it even for JWT and signed streams sessions.
 
-\* It's (almost) impossible to guarantee that `disconnect` callbacks would be called for 100%. There is always a chance of a server crash or `kill -9` or something worse. Consider an alternative approach to tracking client states (see [example](https://github.com/anycable/anycable/issues/99#issuecomment-611998267)).
+**NOTE:** AnyCable tries to make a Disconnect call for active sessions during the server shutdown. However, if the server is killed with `kill -9` or crashes, the disconnect queue is not flushed, and some disconnect events may be lost. If you experience higher queue sizes during deployments, consider increasing the shutdown timeout by tuning the `--shutdown_timeout` parameter.
 
 ## GOMAXPROCS
 

--- a/features/shutdown.testfile
+++ b/features/shutdown.testfile
@@ -1,0 +1,46 @@
+launch :rpc, "bundle exec anyt --only-rpc", env: {"ANYCABLE_DEBUG" => "1"}, capture_output: true
+wait_tcp 50051
+
+launch :anycable,
+  "./dist/anycable-go --disconnect_mode=always --disconnect_rate=1"
+wait_tcp 8080
+
+scenario = [
+  client: {
+    multiplier: 3,
+    actions: [
+      {
+        receive: {
+          "data>": {
+            type: "welcome"
+          }
+        }
+      },
+      {
+        sleep: {
+          time: 4
+        }
+      }
+    ]
+  }
+]
+
+TEST_COMMAND = <<~CMD
+  bundle exec wsdirector ws://localhost:8080/cable -i #{scenario.to_json}
+CMD
+
+launch :wsdirector, TEST_COMMAND
+
+sleep 1
+
+stop :anycable
+stop :rpc
+
+result = stdout(:rpc)
+
+expected = 3
+disconnect_calls = result.scan(/^RPC Disconnect/).size
+
+if disconnect_calls != expected
+  fail "Expected to receive #{expected} Disconnect RPC calls. Got #{disconnect_calls}:\n#{result}"
+end

--- a/node/broker_integration_test.go
+++ b/node/broker_integration_test.go
@@ -307,6 +307,7 @@ func sharedIntegrationHistory(t *testing.T, node *Node, controller *mocks.Contro
 func setupIntegrationNode() (*Node, *mocks.Controller) {
 	config := NewConfig()
 	config.HubGopoolSize = 2
+	config.DisconnectMode = DISCONNECT_MODE_NEVER
 
 	controller := &mocks.Controller{}
 	controller.On("Shutdown").Return(nil)

--- a/node/config.go
+++ b/node/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	HubGopoolSize int
 	// How should ping message timestamp be formatted? ('s' => seconds, 'ms' => milli seconds, 'ns' => nano seconds)
 	PingTimestampPrecision string
+	// For how long to wait for disconnect callbacks to be processed before exiting (seconds)
+	ShutdownTimeout int
 }
 
 // NewConfig builds a new config
@@ -30,5 +32,6 @@ func NewConfig() Config {
 		HubGopoolSize:          16,
 		PingTimestampPrecision: "s",
 		DisconnectMode:         DISCONNECT_MODE_AUTO,
+		ShutdownTimeout:        30,
 	}
 }

--- a/node/disconnect_queue_test.go
+++ b/node/disconnect_queue_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"runtime"
 	"testing"
 
@@ -9,8 +10,9 @@ import (
 
 func TestDisconnectQueue_Run(t *testing.T) {
 	t.Run("Disconnects sessions", func(t *testing.T) {
+		ctx := context.Background()
 		q := newQueue()
-		defer q.Shutdown() //nolint:errcheck
+		defer q.Shutdown(ctx) //nolint:errcheck
 
 		assert.Nil(t, q.Enqueue(NewMockSession("1", q.node)))
 		assert.Equal(t, 1, q.Size())
@@ -30,13 +32,14 @@ func TestDisconnectQueue_Run(t *testing.T) {
 
 func TestDisconnectQueue_Shutdown(t *testing.T) {
 	t.Run("Disconnects sessions", func(t *testing.T) {
+		ctx := context.Background()
 		q := newQueue()
 
 		assert.Nil(t, q.Enqueue(NewMockSession("1", q.node)))
 		assert.Nil(t, q.Enqueue(NewMockSession("2", q.node)))
 		assert.Equal(t, 2, q.Size())
 
-		assert.Nil(t, q.Shutdown())
+		assert.Nil(t, q.Shutdown(ctx))
 		assert.Equal(t, 0, q.Size())
 	})
 
@@ -46,9 +49,10 @@ func TestDisconnectQueue_Shutdown(t *testing.T) {
 
 	t.Run("Allows multiple entering", func(t *testing.T) {
 		q := newQueue()
+		ctx := context.Background()
 
 		for i := 1; i <= 10; i++ {
-			q.Shutdown() // nolint:errcheck
+			q.Shutdown(ctx) // nolint:errcheck
 		}
 	})
 }
@@ -62,8 +66,9 @@ func TestDisconnectQueue_Enqueue(t *testing.T) {
 	})
 
 	t.Run("After shutdown", func(t *testing.T) {
+		ctx := context.Background()
 		q := newQueue()
-		q.Shutdown() // nolint:errcheck
+		q.Shutdown(ctx) // nolint:errcheck
 
 		assert.Nil(t, q.Enqueue(NewMockSession("1", q.node)))
 		assert.Equal(t, 0, q.Size())

--- a/node/disconnector.go
+++ b/node/disconnector.go
@@ -1,11 +1,15 @@
 package node
 
-import "github.com/apex/log"
+import (
+	"context"
+
+	"github.com/apex/log"
+)
 
 // Disconnector is an interface for disconnect queue implementation
 type Disconnector interface {
 	Run() error
-	Shutdown() error
+	Shutdown(ctx context.Context) error
 	Enqueue(*Session) error
 	Size() int
 }
@@ -20,7 +24,7 @@ func (d *NoopDisconnectQueue) Run() error {
 }
 
 // Shutdown does nothing
-func (d *NoopDisconnectQueue) Shutdown() error {
+func (d *NoopDisconnectQueue) Shutdown(ctx context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Make shutdown timeout configurable.

### What changes did you make? (overview)

- [x] Added `--shutdown_timeout` configuration parameter
- [x] Added `wsServer` to the list of _shutdownables_ in the very beginning (so we don't accept new connections as soon as the first signal has been received)
- [x] Refactored `hub.DisconnectSessions` to use contexts and delegate the actual disconnection to the caller. 

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
