### PR TITLE
Ping-related improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Added ability to require `pong` messages from clients (for better detection of broken connections). ([@palkan][])
+
+Use `--pong_timoout=<number of seconds to wait for ping>` option to enable this feature. **NOTE:** This option is only applied to clients using the extended Action Cable protocol.
+
 - Allow configuring ping interval and ping timestamp precision per connection. ([@palkan][])
 
 You can use URL query params to configure ping interval and timestamp precision per connection:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## master
 
+- Allow configuring ping interval and ping timestamp precision per connection. ([@palkan][])
+
+You can use URL query params to configure ping interval and timestamp precision per connection:
+
+For example, using the following URL, you can set the ping interval to 10 seconds and the timestamp precision to milliseconds:
+
+```txt
+ws://localhost:8080/cable?pi=10&ptp=ms
+```
+
 - Fix in-memory streams history retrieval. ([@palkan][])
 
 Keep empty streams in the cache for a longer time, so we re-use the offset. In case the stream has been disposed, we should return an error when the requested offset is out of range.

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -8,10 +8,6 @@ import (
 	"github.com/anycable/anycable-go/common"
 )
 
-const (
-	SESSION_ID_HEADER = "X-ANYCABLE-RESTORE-SID"
-)
-
 // Broadcaster is responsible for fanning-out messages to the stream clients
 // and other nodes
 type Broadcaster interface {

--- a/cli/options.go
+++ b/cli/options.go
@@ -779,6 +779,13 @@ func pingCLIFlags(c *config.Config) []cli.Flag {
 			Value:       c.App.PingTimestampPrecision,
 			Destination: &c.App.PingTimestampPrecision,
 		},
+
+		&cli.IntFlag{
+			Name:        "pong_timeout",
+			Usage:       `How long to wait for a pong response before disconnecting the client (in seconds). Zero means no pongs required`,
+			Value:       c.App.PongTimeout,
+			Destination: &c.App.PongTimeout,
+		},
 	})
 }
 

--- a/cli/options.go
+++ b/cli/options.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/anycable/anycable-go/broker"
 	"github.com/anycable/anycable-go/config"
 	"github.com/anycable/anycable-go/node"
 	"github.com/anycable/anycable-go/version"
@@ -124,11 +123,6 @@ func NewConfigFromCLI(args []string, opts ...cliOption) (*config.Config, error, 
 	}
 
 	c.Headers = strings.Split(strings.ToLower(headers), ",")
-
-	// Read session ID header if using a broker
-	if c.BrokerAdapter != "" {
-		c.Headers = append(c.Headers, broker.SESSION_ID_HEADER)
-	}
 
 	if len(cookieFilter) > 0 {
 		c.Cookies = strings.Split(cookieFilter, ",")

--- a/cli/session_options.go
+++ b/cli/session_options.go
@@ -23,6 +23,10 @@ func (r *Runner) sessionOptionsFromProtocol(protocol string) []node.SessionOptio
 
 	if common.IsExtendedActionCableProtocol(protocol) {
 		opts = append(opts, node.WithResumable(true))
+
+		if r.config.App.PongTimeout > 0 {
+			opts = append(opts, node.WithPongTimeout(time.Duration(r.config.App.PongTimeout)*time.Second))
+		}
 	}
 
 	return opts

--- a/cli/session_options.go
+++ b/cli/session_options.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/server"
+	"github.com/apex/log"
+)
+
+const (
+	pingIntervalParameter  = "pi"
+	pingPrecisionParameter = "ptp"
+)
+
+func (r *Runner) sessionOptionsFromProtocol(protocol string) []node.SessionOption {
+	opts := []node.SessionOption{}
+
+	return opts
+}
+
+func (r *Runner) sessionOptionsFromParams(info *server.RequestInfo) []node.SessionOption {
+	opts := []node.SessionOption{}
+
+	if rawVal := info.Param(pingIntervalParameter); rawVal != "" {
+		val, err := strconv.Atoi(rawVal)
+		if err != nil {
+			log.Warnf("Invalid ping interval value, must be integer: %s", rawVal)
+		} else {
+			opts = append(opts, node.WithPingInterval(time.Duration(val)*time.Second))
+		}
+	}
+
+	if val := info.Param(pingPrecisionParameter); val != "" {
+		opts = append(opts, node.WithPingPrecision(val))
+	}
+
+	return opts
+}

--- a/common/common.go
+++ b/common/common.go
@@ -54,6 +54,7 @@ const (
 	SERVER_RESTART_REASON    = "server_restart"
 	REMOTE_DISCONNECT_REASON = "remote"
 	IDLE_TIMEOUT_REASON      = "idle_timeout"
+	NO_PONG_REASON           = "no_pong"
 	UNAUTHORIZED_REASON      = "unauthorized"
 )
 

--- a/common/common.go
+++ b/common/common.go
@@ -21,6 +21,20 @@ func ActionCableProtocols() []string {
 	return []string{ActionCableV1JSON, ActionCableV1ExtJSON}
 }
 
+func ActionCableExtendedProtocols() []string {
+	return []string{ActionCableV1ExtJSON}
+}
+
+func IsExtendedActionCableProtocol(protocol string) bool {
+	for _, p := range ActionCableExtendedProtocols() {
+		if p == protocol {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Outgoing message types (according to Action Cable protocol)
 const (
 	WelcomeType    = "welcome"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,10 @@ Enable debug mode (more verbose logging).
 
 The number of seconds to wait for the server to shutdown gracefully, i.e., disconnect all active sessions and perform the corresponding Disconnect RPC calls (see below). Default: 30.
 
+**--pong_timeout** (`ANYCABLE_PONG_TIMEOUT`)
+
+For clients using the [extended Action Cable protocol](../misc/action_cable_protocol.md#action-cable-extended-protocol), the number of seconds to wait for the client to respond to the PING message with the PONG command. The default value is zero, meaning that no PONGs are expected. The recommended value to activate this feature is 10 seconds. Requiring pongs helps to detect broken connections faster.
+
 ## Presets
 
 AnyCable-Go comes with a few built-in configuration presets for particular deployments environments, such as Heroku or Fly. The presets are detected and activated automatically. As an indication, you can find a line in the logs:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,19 @@ The preset provides the following defaults:
 - `host`: "0.0.0.0".
 - `http_broadcast_port`: `$PORT` (to make HTTP endpoint accessible from other applications).
 
+## Per-client settings
+
+A client MAY override default values for the settings listed below by providing the corresponding parameters in the WebSocket URL query string:
+
+- `?pi=<seconds>`: ping interval (overrides `--ping_interval`).
+- `?ptp=<s | ms | ns>`: ping timestamp precision (overrides `--ping_timestamp_precision`).
+
+For example, using the following URL, you can set the ping interval to 10 seconds and the timestamp precision to milliseconds:
+
+```txt
+ws://localhost:8080/cable?pi=10&ptp=ms
+```
+
 ## HTTP RPC
 
 When using HTTP RPC, you can specify the following additional options:

--- a/etc/anyt/broker_tests/restore_test.rb
+++ b/etc/anyt/broker_tests/restore_test.rb
@@ -8,7 +8,7 @@ feature "Session cache" do
   end
 
   before do
-    client = build_client(ignore: ["ping"])
+    client = build_client(ignore: ["ping"], protocol: "actioncable-v1-ext-json")
 
     welcome_msg = client.receive
     assert_message({ "type" => "welcome" }, welcome_msg)
@@ -50,7 +50,8 @@ feature "Session cache" do
       ignore: ["ping"],
       headers: {
         "X-ANYCABLE-RESTORE-SID" => @sid
-      }
+      },
+      protocol: "actioncable-v1-ext-json"
     )
 
     assert_message({ "type" => "welcome", "restored" => true }, another_client.receive)

--- a/features/ping.testfile
+++ b/features/ping.testfile
@@ -1,0 +1,45 @@
+launch :rpc, "bundle exec anyt --only-rpc"
+wait_tcp 50051
+
+launch :anycable,
+  "./dist/anycable-go --ping_interval=10"
+wait_tcp 8080
+
+scenario = [
+  client: {
+    multiplier: 1,
+    connection_options: {
+      query: {
+        pi: "1"
+      }
+    },
+    actions: [
+      {
+        receive: {
+          "data>": {
+            type: "welcome"
+          }
+        }
+      },
+      {
+        receive: {
+          "data>": {
+            type: "ping"
+          }
+        }
+      }
+    ]
+  }
+]
+
+TEST_COMMAND = <<~CMD
+  bundle exec wsdirector ws://localhost:8080/cable -i #{scenario.to_json}
+CMD
+
+run :wsdirector, TEST_COMMAND
+
+result = stdout(:wsdirector)
+
+if result !~ /1 clients, 0 failures/
+  fail "Unexpected scenario result:\n#{result}"
+end

--- a/features/ping_pong.testfile
+++ b/features/ping_pong.testfile
@@ -1,0 +1,80 @@
+launch :rpc, "bundle exec anyt --only-rpc"
+wait_tcp 50051
+
+launch :anycable,
+  "./dist/anycable-go --pong_timeout=1"
+wait_tcp 8080
+
+scenario = [
+  client: {
+    multiplier: 1,
+    connection_options: {
+      subprotocol: "actioncable-v1-ext-json",
+      query: {
+        pi: "1",
+        ptp: "ns",
+      }
+    },
+    actions: [
+      {
+        receive: {
+          "data>": {
+            type: "welcome"
+          }
+        }
+      },
+      {
+        receive: {
+          "data>": {
+            type: "ping"
+          }
+        }
+      },
+      {
+        sleep: {
+          time: 0.5
+        }
+      },
+      {
+        send: {
+          data: {
+            command: "pong"
+          }
+        }
+      },
+      {
+        receive: {
+          "data>": {
+            type: "ping"
+          }
+        }
+      },
+      {
+        sleep: {
+          time: 1
+        }
+      },
+      {
+        receive: {
+          data: {
+            type: "disconnect",
+            reason: "no_pong",
+            reconnect: true
+          }
+        }
+      }
+    ]
+  }
+]
+
+TEST_COMMAND = <<~CMD
+  bundle exec wsdirector ws://localhost:8080/cable -i #{scenario.to_json}
+CMD
+
+run :wsdirector, TEST_COMMAND
+
+result = stdout(:wsdirector)
+
+if result !~ /1 clients, 0 failures/
+  fail "Unexpected scenario result:\n#{result}"
+end

--- a/node/broker_integration_test.go
+++ b/node/broker_integration_test.go
@@ -52,7 +52,7 @@ func sharedIntegrationRestore(t *testing.T, node *Node, controller *mocks.Contro
 	sid := "s18"
 	ids := "user:jack"
 
-	prev_session := NewMockSessionWithEnv(sid, node, "ws://test.anycable.io/cable", nil)
+	prev_session := NewMockSessionWithEnv(sid, node, "ws://test.anycable.io/cable", nil, WithResumable(true))
 
 	controller.
 		On("Authenticate", sid, prev_session.env).
@@ -115,7 +115,7 @@ func sharedIntegrationRestore(t *testing.T, node *Node, controller *mocks.Contro
 
 	prev_session.Disconnect("normal", ws.CloseNormalClosure)
 
-	session := NewMockSessionWithEnv("s21", node, fmt.Sprintf("ws://test.anycable.io/cable?sid=%s", sid), nil)
+	session := NewMockSessionWithEnv("s21", node, fmt.Sprintf("ws://test.anycable.io/cable?sid=%s", sid), nil, WithResumable(true), WithPrevSID(sid))
 
 	_, err = node.Authenticate(session)
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func sharedIntegrationRestore(t *testing.T, node *Node, controller *mocks.Contro
 				Transmissions: []string{`{"type":"welcome","restored":false}`},
 			}, nil)
 
-		new_session := NewMockSessionWithEnv("s42", node, fmt.Sprintf("ws://test.anycable.io/cable?sid=%s", sid), nil)
+		new_session := NewMockSessionWithEnv("s42", node, fmt.Sprintf("ws://test.anycable.io/cable?sid=%s", sid), nil, WithResumable(true), WithPrevSID(sid))
 
 		time.Sleep(4 * time.Second)
 

--- a/node/config.go
+++ b/node/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	HubGopoolSize int
 	// How should ping message timestamp be formatted? ('s' => seconds, 'ms' => milli seconds, 'ns' => nano seconds)
 	PingTimestampPrecision string
+	// For how long to wait for pong message before disconnecting (seconds)
+	PongTimeout int
 	// For how long to wait for disconnect callbacks to be processed before exiting (seconds)
 	ShutdownTimeout int
 }

--- a/node/node.go
+++ b/node/node.go
@@ -127,6 +127,8 @@ func (n *Node) Instrumenter() metrics.Instrumenter {
 func (n *Node) HandleCommand(s *Session, msg *common.Message) (err error) {
 	s.Log.Debugf("Incoming message: %v", msg)
 	switch msg.Command {
+	case "pong":
+		s.handlePong(msg)
 	case "subscribe":
 		_, err = n.Subscribe(s, msg)
 	case "unsubscribe":

--- a/node/node_mocks_test.go
+++ b/node/node_mocks_test.go
@@ -26,7 +26,7 @@ func NewMockNode() *Node {
 }
 
 // NewMockSession returns a new session with a specified uid and identifiers equal to uid
-func NewMockSession(uid string, node *Node) *Session {
+func NewMockSession(uid string, node *Node, opts ...SessionOption) *Session {
 	session := Session{
 		executor:      node,
 		closed:        true,
@@ -41,14 +41,19 @@ func NewMockSession(uid string, node *Node) *Session {
 
 	session.SetIdentifiers(uid)
 	session.conn = mocks.NewMockConnection()
+
+	for _, opt := range opts {
+		opt(&session)
+	}
+
 	go session.SendMessages()
 
 	return &session
 }
 
 // NewMockSession returns a new session with a specified uid, path and headers, and identifiers equal to uid
-func NewMockSessionWithEnv(uid string, node *Node, url string, headers *map[string]string) *Session {
-	session := NewMockSession(uid, node)
+func NewMockSessionWithEnv(uid string, node *Node, url string, headers *map[string]string, opts ...SessionOption) *Session {
+	session := NewMockSession(uid, node, opts...)
 	session.env = common.NewSessionEnv(url, headers)
 	return session
 }

--- a/node/session_test.go
+++ b/node/session_test.go
@@ -204,24 +204,6 @@ func TestCacheEntryEmptySession(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPrevSid(t *testing.T) {
-	session := Session{}
-	headers := make(map[string]string)
-	session.env = common.NewSessionEnv("ws://example.dev/cable", nil)
-	assert.Equal(t, "", session.PrevSid())
-
-	session.env = common.NewSessionEnv("ws://example.dev/cable?sid=123", &headers)
-	assert.Equal(t, "123", session.PrevSid())
-
-	session.env = common.NewSessionEnv("http://example.dev/cable?jid=xxxx&sid=213", &headers)
-	assert.Equal(t, "213", session.PrevSid())
-
-	headers["X-ANYCABLE-RESTORE-SID"] = "456"
-
-	session.env = common.NewSessionEnv("http://example.dev/cable?jid=xxxx&sid=213", &headers)
-	assert.Equal(t, "456", session.PrevSid())
-}
-
 func TestMarkDisconnectable(t *testing.T) {
 	session := Session{}
 

--- a/server/request_info.go
+++ b/server/request_info.go
@@ -17,6 +17,7 @@ type RequestInfo struct {
 	UID     string
 	URL     string
 	Headers *map[string]string
+	Params  map[string]string
 }
 
 func NewRequestInfo(r *http.Request, extractor HeadersExtractor) (*RequestInfo, error) {
@@ -45,7 +46,22 @@ func NewRequestInfo(r *http.Request, extractor HeadersExtractor) (*RequestInfo, 
 		url = fmt.Sprintf("%s%s%s", scheme, r.Host, url)
 	}
 
-	return &RequestInfo{UID: uid, Headers: &headers, URL: url}, nil
+	params := make(map[string]string)
+	urlParams := r.URL.Query()
+
+	for k, v := range urlParams {
+		params[k] = v[len(v)-1]
+	}
+
+	return &RequestInfo{UID: uid, Headers: &headers, URL: url, Params: params}, nil
+}
+
+func (i *RequestInfo) Param(key string) string {
+	if i.Params == nil {
+		return ""
+	}
+
+	return i.Params[key]
 }
 
 // FetchUID safely extracts uid from `X-Request-ID` header or generates a new one

--- a/server/request_info_test.go
+++ b/server/request_info_test.go
@@ -64,4 +64,18 @@ func TestRequestInfo(t *testing.T) {
 		blank_info := RequestInfo{}
 		assert.Equal(t, "", blank_info.Param("pi"))
 	})
+
+	t.Run("With AnyCable Headers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "ws://anycable.io/cable?pi=3&pp=no&pi=5", nil)
+		req.Header.Set("x-anycable-sid", "432")
+		req.Header.Set("X-AnyCable-Ping-Interval", "10")
+		info, err := NewRequestInfo(req, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "432", info.AnyCableHeader("X-ANYCABLE-SID"))
+		assert.Equal(t, "10", info.AnyCableHeader("x-anycable-ping-interval"))
+
+		blank_info := RequestInfo{}
+		assert.Equal(t, "", blank_info.AnyCableHeader("SID"))
+	})
 }

--- a/server/request_info_test.go
+++ b/server/request_info_test.go
@@ -52,4 +52,16 @@ func TestRequestInfo(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "ws://anycable.io/cable", info.URL)
 	})
+
+	t.Run("With params", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "ws://anycable.io/cable?pi=3&pp=no&pi=5", nil)
+		info, err := NewRequestInfo(req, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "5", info.Param("pi"))
+		assert.Equal(t, "no", info.Param("pp"))
+
+		blank_info := RequestInfo{}
+		assert.Equal(t, "", blank_info.Param("pi"))
+	})
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

This PRs combines several improvements regarding server-client pings and session configuration.

### What changes did you make? (overview)

- [x] Added ability to configure ping interval and precision per client.
- [x] Refactor setting protocol-specific session options
  - [x] Do not store sessions not using the extended protocol in cache
  - [x] Move previous session ID extraction from `session.go` to `session_options.go` (session shouldn't care about where the ID is coming from) 
  - [x] Extract protocol-specific session configuration (that would allow re-using the same endpoint for different protocols based on sub-protocol)
- [x] Add small jitter to pings (so they're not happening simultaneously when tons of clients connecting at the same time)
- [x] Add `pong`-s support (when the extended protocol is used) 

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
