### PR TITLE
SSE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add Server-Sent Events support. ([@palkan][])
+
 - Add `disconnect_backlog_size` option to control the buffer size for the disconnect queue.
 
 ## 1.4.3 (2023-08-10)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -296,7 +296,7 @@ func (r *Runner) Run() error {
 			wsServer.Address(), r.config.SSE.Path,
 		)
 
-		sseHandler, err := r.defaultSSEHandler(appNode, r.config)
+		sseHandler, err := r.defaultSSEHandler(appNode, wsServer.ShutdownCtx(), r.config)
 
 		if err != nil {
 			return errorx.Decorate(err, "!!! Failed to initialize SSE handler !!!")
@@ -416,9 +416,9 @@ func (r *Runner) defaultWebSocketHandler(n *node.Node, c *config.Config) (http.H
 	}), nil
 }
 
-func (r *Runner) defaultSSEHandler(n *node.Node, c *config.Config) (http.Handler, error) {
+func (r *Runner) defaultSSEHandler(n *node.Node, ctx context.Context, c *config.Config) (http.Handler, error) {
 	extractor := server.DefaultHeadersExtractor{Headers: c.Headers, Cookies: c.Cookies}
-	handler := sse.SSEHandler(n, &extractor, &c.SSE)
+	handler := sse.SSEHandler(n, ctx, &extractor, &c.SSE)
 
 	return handler, nil
 }

--- a/cli/options.go
+++ b/cli/options.go
@@ -83,6 +83,7 @@ func NewConfigFromCLI(args []string, opts ...cliOption) (*config.Config, error, 
 	flags = append(flags, signedStreamsCLIFlags(&c)...)
 	flags = append(flags, statsdCLIFlags(&c)...)
 	flags = append(flags, embeddedNatsCLIFlags(&c, &enatsRoutes, &enatsGateways)...)
+	flags = append(flags, sseCLIFlags(&c)...)
 	flags = append(flags, miscCLIFlags(&c, &presets)...)
 
 	app := &cli.App{
@@ -186,6 +187,8 @@ and will be removed in the next major release of anycable-go.
 Use shutdown_timeout instead.`)
 	}
 
+	c.SSE.AllowedOrigins = c.WS.AllowedOrigins
+
 	return &c, nil, false
 }
 
@@ -210,6 +213,7 @@ const (
 	embeddedNatsCategoryDescription  = "EMBEDDED NATS:"
 	miscCategoryDescription          = "MISC:"
 	brokerCategoryDescription        = "BROKER:"
+	sseCategoryDescription           = "SERVER-SENT EVENTS:"
 
 	envPrefix = "ANYCABLE_"
 )
@@ -875,6 +879,24 @@ func statsdCLIFlags(c *config.Config) []cli.Flag {
 			Usage:       `One of "datadog", "influxdb", or "graphite"`,
 			Value:       c.Metrics.Statsd.TagFormat,
 			Destination: &c.Metrics.Statsd.TagFormat,
+		},
+	})
+}
+
+// sseCLIFlags returns CLI flags for SSE
+func sseCLIFlags(c *config.Config) []cli.Flag {
+	return withDefaults(sseCategoryDescription, []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "sse",
+			Usage:       "Enable SSE endpoint",
+			Value:       c.SSE.Enabled,
+			Destination: &c.SSE.Enabled,
+		},
+		&cli.StringFlag{
+			Name:        "sse_path",
+			Usage:       "SSE endpoint path",
+			Value:       c.SSE.Path,
+			Destination: &c.SSE.Path,
 		},
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	rconfig "github.com/anycable/anycable-go/redis"
 	"github.com/anycable/anycable-go/rpc"
 	"github.com/anycable/anycable-go/server"
+	"github.com/anycable/anycable-go/sse"
 	"github.com/anycable/anycable-go/ws"
 )
 
@@ -46,6 +47,7 @@ type Config struct {
 	Rails                rails.Config
 	EmbedNats            bool
 	EmbeddedNats         enats.Config
+	SSE                  sse.Config
 	UserPresets          []string
 }
 
@@ -73,6 +75,7 @@ func NewConfig() Config {
 		JWT:              identity.NewJWTConfig(""),
 		Rails:            rails.NewConfig(),
 		EmbeddedNats:     enats.NewConfig(),
+		SSE:              sse.NewConfig(),
 	}
 
 	return config

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -81,7 +81,7 @@ data: {"type":"confirm_subscription","identifier":"{\"channel\":\"ChatChannel\"}
 event: ping
 data: {"type":"ping","message":1694041735}
 
-data: {"identifier":"{\"channel\":\"ChatChannel\"}","message":{"message":"hello"}}
+data: {"message":"hello"}
 ...
 ```
 
@@ -95,7 +95,7 @@ Note that you must process different event types yourself. See below for the for
 
 The server-client communication format is designed as follows:
 
-- The `data` field contains the message payload (JSON string)
+- The `data` field contains the message payload. **IMPORTANT**: for clients connecting via a GET request, the payload only contains the `message` part of the original Action Cable payload; clients connecting via POST requests receive the full payload (e.g., `{"identifier":, "message": {"foo":1}}`).
 - The optional `event` field contains the message type (if any); for example, `welcome`, `confirm_subscription`, `ping`
 - The optional `id` field contains the message ID if reliable streaming is enabled. The message ID has a form or `<offset>/<stream_id>/<epoch>` (see [Extended Action Cable protocol](/misc/action_cable_protocol.md#action-cable-extended-protocol))
 - The optional `retry` field contains the reconnection interval in milliseconds. We only set this field for `disconnect` messages with `reconnect: false` (it's set to a reasonably high number to prevent automatic reconnection attempts by EventSource).
@@ -115,6 +115,15 @@ event: ping
 data: {"type":"ping","message":1694041735}
 
 
+<!-- GET connection (e.g., EventSource) -->
+data: {"message":"hello"}
+id: 1/chat_42/y2023
+
+data: {"message":"good-bye"}
+id: 2/chat_42/y2023
+
+
+<!-- POST connection  -->
 data: {"identifier":"{\"channel\":\"ChatChannel\"}","message":{"message":"hello"}}
 id: 1/chat_42/y2023
 

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -1,0 +1,133 @@
+# Server-sent events
+
+In addition to WebSockets and [long polling](./long_polling.md)), AnyCable also allows you to use [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) (SSE) as a transport for receiving live updates.
+
+SSE is supported by all modern browsers (see [caniuse](https://caniuse.com/eventsource)) and is a good alternative to WebSockets if you don't need to send messages from the client to the server and don't want to deal with Action Cable or AnyCable SDKs: you can use native browsers `EventSource` API to establish a reliable connection or set up HTTP streaming manually using your tool of choice (e.g., `fetch` in a browser, `curl` in a terminal, etc.).
+
+## Configuration
+
+You must opt-in to enable SSE support in AnyCable. To do so, you must provide the `--sse` or set the `ANYCABLE_SSE` environment variable to `true`:
+
+```sh
+$ anycable-go --sse
+
+INFO 2023-09-06T22:52:04.229Z context=main Starting GoBenchCable 1.4.4 (with mruby 1.2.0 (2015-11-17)) (pid: 39193, open file limit: 122880, gomaxprocs: 8)
+...
+INFO 2023-09-06T22:52:04.229Z context=main Handle WebSocket connections at http://localhost:8080/cable
+INFO 2023-09-06T22:52:04.229Z context=main Handle SSE requests at http://localhost:8080/events
+...
+```
+
+The default path for SSE connections is `/events`, but you can configure it via the `--sse_path` configuration option.
+
+## Usage with EventSource
+
+The easiest way to use SSE is to use the native `EventSource` API. For that, you MUST provide a URL to the SSE endpoint and pass the channel information in query parameters (EventSource only supports GET requests, so we cannot use the body). For example:
+
+```js
+const source = new EventSource("http://localhost:8080/events?channel=ChatChannel");
+
+// Setup an event listener to handle incoming messages
+source.addEventListener("message", (e) => {
+  // e.data contains the message payload as a JSON string, so we need to parse it
+  console.log(JSON.parse(e.data));
+});
+```
+
+The snippet above will establish a connection to the SSE endpoint and subscribe to the `ChatChannel` channel.
+
+If you need to subscribe to a channel with parameters, you MUST provide the fully qualified channel identifier via the `identifier` query parameter:
+
+```js
+const identifier = JSON.stringify({
+  channel: "BenchmarkChannel",
+  room_id: 42,
+});
+
+const source = new EventSource(
+  `http://localhost:8080/events?identifier=${encodeURIComponent(identifier)}`
+);
+
+// ...
+```
+
+**IMPORTANT**: You MUST specify either `channel` or `identifier` query parameters. If you don't, the connection will be rejected.
+
+### Reliability
+
+EventSource is a reliable transport, which means that it will automatically reconnect if the connection is lost.
+
+EventSource also keeps track of received messages and sends the last consumed ID on reconnection. To leverage this feature, you MUST enable AnyCable [reliable streams](./reliable_streams.md) functionality. No additional client-side configuration is required.
+
+**IMPORTANT**: EventSource is assumed to be used with a single stream of data. If you subscribe a client to multiple Action Cable streams (e.g., multiple `stream_from` calls), the last consumed ID will be sent only for the last observed stream.
+
+### Unauthorized connections or rejected subscriptions
+
+If the connection is unauthorized or the subscription is rejected, the server will respond with a `401` status code and close the connection. EventSource will automatically reconnect after a short delay. Please, make sure you handle `error` events and close the connection if you don't want to reconnect.
+
+## Usage with other HTTP clients
+
+You can also use any other HTTP client to establish a connection to the SSE endpoint. For example, you can use `curl`:
+
+```sh
+$ curl -N "http://localhost:8080/events?channel=ChatChannel"
+
+event: welcome
+data: {"type":"welcome"}
+
+event: confirm_subscription
+data: {"type":"confirm_subscription","identifier":"{\"channel\":\"ChatChannel\"}"}
+
+event: ping
+data: {"type":"ping","message":1694041735}
+
+data: {"identifier":"{\"channel\":\"ChatChannel\"}","message":{"message":"hello"}}
+...
+```
+
+AnyCable also supports setting up a streaming HTTP connection via POST requests. In this case, you can provide a list of client-server commands in the request body using the JSONL (JSON lines) format.
+
+<!-- TODO: fetch example -->
+
+Note that you must process different event types yourself. See below for the format.
+
+## Action Cable over SSE format
+
+The server-client communication format is designed as follows:
+
+- The `data` field contains the message payload (JSON string)
+- The optional `event` field contains the message type (if any); for example, `welcome`, `confirm_subscription`, `ping`
+- The optional `id` field contains the message ID if reliable streaming is enabled. The message ID has a form or `<offset>/<stream_id>/<epoch>` (see [Extended Action Cable protocol](/misc/action_cable_protocol.md#action-cable-extended-protocol))
+- The optional `retry` field contains the reconnection interval in milliseconds. We only set this field for `disconnect` messages with `reconnect: false` (it's set to a reasonably high number to prevent automatic reconnection attempts by EventSource).
+
+Here is an example of a stream of messages from the server:
+
+```txt
+event: welcome
+data: {"type":"welcome"}
+
+
+event: confirm_subscription
+data: {"type":"confirm_subscription","identifier":"{\"channel\":\"ChatChannel\"}"}
+
+
+event: ping
+data: {"type":"ping","message":1694041735}
+
+
+data: {"identifier":"{\"channel\":\"ChatChannel\"}","message":{"message":"hello"}}
+id: 1/chat_42/y2023
+
+
+data: {"identifier":"{\"channel\":\"ChatChannel\"}","message":{"message":"good-bye"}}
+id: 2/chat_42/y2023
+
+
+event: ping
+data: {"type":"ping","message":1694044435}
+
+
+event: disconnect
+data: {"type":"disconnect","reason":"remote","reconnect":false}
+retry: 31536000000
+```

--- a/features/sse.testfile
+++ b/features/sse.testfile
@@ -104,7 +104,7 @@ streaming_request(URI(url)) do |stream|
 
   broadcast_event = stream.resume
 
-  if broadcast_event.data.fetch("message") != {"text" => "Hello, stream!"}
+  if broadcast_event.data != {"text" => "Hello, stream!"}
     fail "Expected broadcast data, got: #{broadcast_event.data}"
   end
 
@@ -125,7 +125,7 @@ streaming_request(URI(url), headers: {"Last-Event-ID" => last_id}) do |stream|
   # And now we should receive the missed message
   missed_message = stream.resume
 
-  if missed_message.data.fetch("message") != {"text" => "Where are you, stream?"}
+  if missed_message.data != {"text" => "Where are you, stream?"}
     fail "Expected missed message, got: #{missed_message.data}"
   end
 end

--- a/features/sse.testfile
+++ b/features/sse.testfile
@@ -1,0 +1,131 @@
+launch :anycable,
+  "./dist/anycable-go --sse --turbo_rails_cleartext --jwt_id_key=qwerty --broadcast_adapter=http --presets=broker"
+
+wait_tcp 8080
+
+payload = {ext: {}.to_json, exp: (Time.now.to_i + 60)}
+
+token = ::JWT.encode(payload, "qwerty", "HS256")
+stream_name = "chat/2023"
+
+require "uri"
+require "net/http"
+require "fiber"
+
+identifier = URI.encode_www_form_component({channel: "Turbo::StreamsChannel", signed_stream_name: stream_name}.to_json)
+
+url = "http://localhost:8080/events?jid=#{token}&identifier=#{identifier}"
+
+Event = Struct.new(:type, :data, :id, :retry)
+
+def broadcast(stream, data)
+  uri = URI.parse("http://localhost:8090/_broadcast")
+  header = {"Content-Type": "application/json"}
+  data = {stream: stream, data: data.to_json}
+  http = Net::HTTP.new(uri.host, uri.port)
+  request = Net::HTTP::Post.new(uri.request_uri, header)
+  request.body = data.to_json
+  response = http.request(request)
+
+  if response.code != "201"
+    fail "Broadcast returned unexpected status: #{response.code}"
+  end
+end
+
+def parse_sse_chunk(chunk)
+  event = Event.new
+  chunk.split("\n").each do |line|
+    field, value = line.split(":", 2).map(&:strip)
+
+    case field
+    when "data"
+      event.data = JSON.parse(value)
+    when "event"
+      event.type = value
+    when "id"
+      event.id = value
+    when "retry"
+      event.retry = value.to_i
+    end
+  end
+  event
+end
+
+def streaming_request(uri, headers: {})
+  begin
+    fiber = Fiber.new do
+      Net::HTTP.start(uri.host, uri.port, read_timeout: 2) do |http|
+        request = Net::HTTP::Get.new(uri)
+        headers.each do |key, value|
+          request[key] = value
+        end
+        catch :stop do
+          http.request(request) do |response|
+            response.read_body do |chunk|
+              chunk.split("\n\n").each do |raw_event|
+                event = parse_sse_chunk(raw_event)
+                # ignore pings
+                next if event.type == "ping"
+
+                cmd = Fiber.yield(event)
+                if cmd == :stop
+                  throw :stop
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    yield fiber
+  rescue => e
+    fiber.resume(:stop)
+    raise
+  end
+end
+
+last_id = nil
+
+streaming_request(URI(url)) do |stream|
+  first_event = stream.resume
+
+  if first_event.type != "welcome"
+    fail "Expected welcome, got: #{first_event}"
+  end
+
+  second_event = stream.resume
+
+  if second_event.type != "confirm_subscription"
+    fail "Expected confirm_subscription, got: #{second_event}"
+  end
+
+  # Broadcast a message
+  broadcast stream_name, {"text" => "Hello, stream!"}
+
+  broadcast_event = stream.resume
+
+  if broadcast_event.data.fetch("message") != {"text" => "Hello, stream!"}
+    fail "Expected broadcast data, got: #{broadcast_event.data}"
+  end
+
+  last_id = broadcast_event.id
+
+  # Stop first session
+  stream.resume(:stop)
+end
+
+# Broadcast another message
+broadcast stream_name, {"text" => "Where are you, stream?"}
+
+# Start new session with last ID
+streaming_request(URI(url), headers: {"Last-Event-ID" => last_id}) do |stream|
+  fail "Expected welcome" unless stream.resume.type == "welcome"
+  fail "Expected confirmation" unless stream.resume.type == "confirm_subscription"
+
+  # And now we should receive the missed message
+  missed_message = stream.resume
+
+  if missed_message.data.fetch("message") != {"text" => "Where are you, stream?"}
+    fail "Expected missed message, got: #{missed_message.data}"
+  end
+end

--- a/forspell.dict
+++ b/forspell.dict
@@ -62,3 +62,5 @@ realtime-ification
 Posthog
 resumable
 ack
+caniuse
+reconnection

--- a/node/node.go
+++ b/node/node.go
@@ -665,6 +665,10 @@ func (n *Node) markDisconnectable(s *Session, interest int) {
 	}
 }
 
+func (n *Node) Size() int {
+	return n.hub.Size()
+}
+
 func transmit(s *Session, transmissions []string) {
 	for _, msg := range transmissions {
 		s.SendJSONTransmission(msg)

--- a/node/session.go
+++ b/node/session.go
@@ -486,6 +486,10 @@ func (s *Session) disconnectFromNode() {
 	s.mu.Unlock()
 }
 
+func (s *Session) DisconnectNow(reason string, code int) {
+	s.disconnectNow(reason, code)
+}
+
 func (s *Session) disconnectNow(reason string, code int) {
 	s.disconnectFromNode()
 	s.writeFrame(&ws.SentFrame{ // nolint:errcheck

--- a/node/session.go
+++ b/node/session.go
@@ -491,6 +491,13 @@ func (s *Session) DisconnectNow(reason string, code int) {
 }
 
 func (s *Session) disconnectNow(reason string, code int) {
+	s.mu.Lock()
+	if !s.Connected {
+		s.mu.Unlock()
+		return
+	}
+	s.mu.Unlock()
+
 	s.disconnectFromNode()
 	s.writeFrame(&ws.SentFrame{ // nolint:errcheck
 		FrameType:   ws.CloseFrame,

--- a/server/cors.go
+++ b/server/cors.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func WriteCORSHeaders(w http.ResponseWriter, r *http.Request, origins []string) {
+	if len(origins) == 0 {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	} else {
+		origin := strings.ToLower(r.Header.Get("Origin"))
+		u, err := url.Parse(origin)
+		if err == nil {
+			for _, host := range origins {
+				if host[0] == '*' && strings.HasSuffix(u.Host, host[1:]) {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+				}
+				if u.Host == host {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+				}
+			}
+		}
+	}
+
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, X-Request-ID, Content-Type, Accept, X-CSRF-Token, Authorization")
+}

--- a/sse/config.go
+++ b/sse/config.go
@@ -1,0 +1,19 @@
+package sse
+
+// Long-polling configuration
+type Config struct {
+	Enabled bool
+	// Path is the URL path to handle long-polling requests
+	Path string
+	// List of allowed origins for CORS requests
+	// We inherit it from the ws.Config
+	AllowedOrigins string
+}
+
+// NewConfig creates a new Config with default values.
+func NewConfig() Config {
+	return Config{
+		Enabled: false,
+		Path:    "/events",
+	}
+}

--- a/sse/config.go
+++ b/sse/config.go
@@ -1,5 +1,9 @@
 package sse
 
+const (
+	defaultMaxBodySize = 65536 // 64 kB
+)
+
 // Long-polling configuration
 type Config struct {
 	Enabled bool

--- a/sse/connection.go
+++ b/sse/connection.go
@@ -1,0 +1,137 @@
+package sse
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/ws"
+	"github.com/apex/log"
+)
+
+type Connection struct {
+	writer http.ResponseWriter
+
+	ctx      context.Context
+	cancelFn context.CancelFunc
+
+	done        bool
+	established bool
+	// Backlog is used to store messages sent to client before connection is established
+	backlog *bytes.Buffer
+
+	mu sync.Mutex
+}
+
+var _ node.Connection = (*Connection)(nil)
+
+// NewConnection creates a new long-polling connection wrapper
+func NewConnection(w http.ResponseWriter) *Connection {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Connection{
+		writer:   w,
+		backlog:  bytes.NewBuffer(nil),
+		ctx:      ctx,
+		cancelFn: cancel,
+	}
+}
+
+func (c *Connection) Read() ([]byte, error) {
+	return nil, errors.New("unsupported")
+}
+
+func (c *Connection) Write(msg []byte, deadline time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.done {
+		return nil
+	}
+
+	if !c.established {
+		c.backlog.Write(msg)
+		c.backlog.Write([]byte("\n\n"))
+		return nil
+	}
+
+	_, err := c.writer.Write(msg)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.writer.Write([]byte("\n\n"))
+
+	if err != nil {
+		return err
+	}
+
+	c.writer.(http.Flusher).Flush()
+
+	return nil
+}
+
+func (c *Connection) WriteBinary(msg []byte, deadline time.Time) error {
+	return errors.New("unsupported")
+}
+
+func (c *Connection) Context() context.Context {
+	return c.ctx
+}
+
+func (c *Connection) Close(code int, reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.done {
+		return
+	}
+
+	log.Warnf("Closing connection with code %d and reason %s", code, reason)
+
+	c.done = true
+
+	c.cancelFn()
+}
+
+// Mark as closed to avoid writing to closed connection
+func (c *Connection) Established() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.established = true
+
+	if c.backlog.Len() > 0 {
+		c.writer.Write(c.backlog.Bytes()) // nolint: errcheck
+		c.writer.(http.Flusher).Flush()
+		c.backlog.Reset()
+	}
+}
+
+func (c *Connection) Descriptor() net.Conn {
+	return nil
+}
+
+func wsCodeToHTTP(code int, reason string) int {
+	// Only convert known WS codes
+	switch code {
+	case ws.CloseNormalClosure:
+		if reason == "Auth Failed" {
+			return http.StatusUnauthorized
+		}
+		return http.StatusOK
+	case ws.CloseGoingAway:
+		return http.StatusServiceUnavailable
+	case ws.CloseAbnormalClosure:
+		return http.StatusInternalServerError
+	case ws.CloseInternalServerErr:
+		return http.StatusInternalServerError
+	}
+
+	return code
+}

--- a/sse/connection.go
+++ b/sse/connection.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/anycable/anycable-go/node"
-	"github.com/anycable/anycable-go/ws"
-	"github.com/apex/log"
 )
 
 type Connection struct {
@@ -92,8 +90,6 @@ func (c *Connection) Close(code int, reason string) {
 		return
 	}
 
-	log.Warnf("Closing connection with code %d and reason %s", code, reason)
-
 	c.done = true
 
 	c.cancelFn()
@@ -115,23 +111,4 @@ func (c *Connection) Established() {
 
 func (c *Connection) Descriptor() net.Conn {
 	return nil
-}
-
-func wsCodeToHTTP(code int, reason string) int {
-	// Only convert known WS codes
-	switch code {
-	case ws.CloseNormalClosure:
-		if reason == "Auth Failed" {
-			return http.StatusUnauthorized
-		}
-		return http.StatusOK
-	case ws.CloseGoingAway:
-		return http.StatusServiceUnavailable
-	case ws.CloseAbnormalClosure:
-		return http.StatusInternalServerError
-	case ws.CloseInternalServerErr:
-		return http.StatusInternalServerError
-	}
-
-	return code
 }

--- a/sse/connection_test.go
+++ b/sse/connection_test.go
@@ -79,15 +79,6 @@ func TestConnection_Read(t *testing.T) {
 	assert.Equal(t, []byte(nil), msg)
 }
 
-func TestWsCodeToHTTP(t *testing.T) {
-	// Verify that WebSocket codes are mapped to HTTP codes correctly
-	assert.Equal(t, http.StatusOK, wsCodeToHTTP(ws.CloseNormalClosure, "Ok"))
-	assert.Equal(t, http.StatusUnauthorized, wsCodeToHTTP(ws.CloseNormalClosure, "Auth Failed"))
-	assert.Equal(t, http.StatusServiceUnavailable, wsCodeToHTTP(ws.CloseGoingAway, "Server Restart"))
-	assert.Equal(t, http.StatusInternalServerError, wsCodeToHTTP(ws.CloseAbnormalClosure, "Internal Error"))
-	assert.Equal(t, http.StatusInternalServerError, wsCodeToHTTP(ws.CloseInternalServerErr, "Internal Error"))
-}
-
 func TestConnection_Descriptor(t *testing.T) {
 	w := httptest.NewRecorder()
 	c := NewConnection(w)

--- a/sse/connection_test.go
+++ b/sse/connection_test.go
@@ -1,0 +1,96 @@
+package sse
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/anycable/anycable-go/ws"
+	"github.com/stretchr/testify/assert"
+)
+
+func (c *Connection) testResponse() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.writer.(*httptest.ResponseRecorder).Body.String()
+}
+
+func (c *Connection) testStatus() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.writer.(*httptest.ResponseRecorder).Code
+}
+
+func TestConnection_Write(t *testing.T) {
+	w := httptest.NewRecorder()
+	c := NewConnection(w)
+
+	msg := []byte("hello, world!")
+	err := c.Write(msg, time.Now().Add(1*time.Second))
+
+	assert.NoError(t, err)
+
+	assert.Empty(t, c.testResponse())
+
+	c.Established()
+
+	assert.Equal(t, http.StatusOK, c.testStatus())
+	assert.Equal(t, "hello, world!\n\n", c.testResponse())
+}
+
+func TestConnection_Close(t *testing.T) {
+	t.Run("Close cancels the context", func(t *testing.T) {
+		// Create a new connection
+		w := httptest.NewRecorder()
+		c := NewConnection(w)
+
+		ctx := c.Context()
+
+		c.Close(ws.CloseNormalClosure, "bye")
+
+		<-ctx.Done()
+		assert.True(t, c.done)
+
+		c.Close(ws.CloseNormalClosure, "bye")
+	})
+}
+
+func TestConnection_WriteBinary(t *testing.T) {
+	w := httptest.NewRecorder()
+	c := NewConnection(w)
+
+	msg := []byte{0x01, 0x02, 0x03}
+	err := c.WriteBinary(msg, time.Now().Add(1*time.Second))
+
+	assert.Error(t, err)
+	assert.Equal(t, []byte(nil), w.Body.Bytes())
+}
+
+func TestConnection_Read(t *testing.T) {
+	w := httptest.NewRecorder()
+	c := NewConnection(w)
+
+	msg, err := c.Read()
+
+	assert.Error(t, err)
+	assert.Equal(t, []byte(nil), msg)
+}
+
+func TestWsCodeToHTTP(t *testing.T) {
+	// Verify that WebSocket codes are mapped to HTTP codes correctly
+	assert.Equal(t, http.StatusOK, wsCodeToHTTP(ws.CloseNormalClosure, "Ok"))
+	assert.Equal(t, http.StatusUnauthorized, wsCodeToHTTP(ws.CloseNormalClosure, "Auth Failed"))
+	assert.Equal(t, http.StatusServiceUnavailable, wsCodeToHTTP(ws.CloseGoingAway, "Server Restart"))
+	assert.Equal(t, http.StatusInternalServerError, wsCodeToHTTP(ws.CloseAbnormalClosure, "Internal Error"))
+	assert.Equal(t, http.StatusInternalServerError, wsCodeToHTTP(ws.CloseInternalServerErr, "Internal Error"))
+}
+
+func TestConnection_Descriptor(t *testing.T) {
+	w := httptest.NewRecorder()
+	c := NewConnection(w)
+
+	assert.Nil(t, c.Descriptor())
+}

--- a/sse/encoder.go
+++ b/sse/encoder.go
@@ -15,6 +15,8 @@ const sseEncoderID = "sse"
 // Tell the client to reconnect in a year in case we don't really want it to re-connect
 const retryNoReconnect = 31536000000
 
+const lastIdDelimeter = "/"
+
 // Encoder is responsible for converting messages to SSE format (event:, data:, etc.)
 // NOTE: It's only used to encode messages from server to client.
 type Encoder struct {
@@ -39,7 +41,7 @@ func (Encoder) Encode(msg encoders.EncodedMessage) (*ws.SentFrame, error) {
 
 	if reply, ok := msg.(*common.Reply); ok {
 		if reply.Offset > 0 && reply.Epoch != "" && reply.StreamID != "" {
-			payload += "\nid: " + fmt.Sprintf("%d/%s/%s", reply.Offset, reply.Epoch, reply.StreamID)
+			payload += "\nid: " + fmt.Sprintf("%d%s%s%s%s", reply.Offset, lastIdDelimeter, reply.Epoch, lastIdDelimeter, reply.StreamID)
 		}
 	}
 

--- a/sse/encoder.go
+++ b/sse/encoder.go
@@ -1,0 +1,68 @@
+package sse
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/encoders"
+	"github.com/anycable/anycable-go/ws"
+)
+
+const sseEncoderID = "sse"
+
+// Tell the client to reconnect in a year in case we don't really want it to re-connect
+const retryNoReconnect = 31536000000
+
+// Encoder is responsible for converting messages to SSE format (event:, data:, etc.)
+// NOTE: It's only used to encode messages from server to client.
+type Encoder struct {
+}
+
+func (Encoder) ID() string {
+	return sseEncoderID
+}
+
+func (Encoder) Encode(msg encoders.EncodedMessage) (*ws.SentFrame, error) {
+	msgType := msg.GetType()
+
+	b, err := json.Marshal(&msg)
+	if err != nil {
+		panic("Failed to build JSON 😲")
+	}
+
+	payload := "data: " + string(b)
+	if msgType != "" {
+		payload = "event: " + msgType + "\n" + payload
+	}
+
+	if reply, ok := msg.(*common.Reply); ok {
+		if reply.Offset > 0 && reply.Epoch != "" && reply.StreamID != "" {
+			payload += "\nid: " + fmt.Sprintf("%d/%s/%s", reply.Offset, reply.Epoch, reply.StreamID)
+		}
+	}
+
+	if msgType == "disconnect" {
+		dmsg, ok := msg.(*common.DisconnectMessage)
+		if ok && !dmsg.Reconnect {
+			payload += "\nretry: " + fmt.Sprintf("%d", retryNoReconnect)
+		}
+	}
+
+	return &ws.SentFrame{FrameType: ws.TextFrame, Payload: []byte(payload)}, nil
+}
+
+func (e Encoder) EncodeTransmission(raw string) (*ws.SentFrame, error) {
+	msg := common.Reply{}
+
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		return nil, err
+	}
+
+	return e.Encode(&msg)
+}
+
+func (Encoder) Decode(raw []byte) (*common.Message, error) {
+	return nil, errors.New("unsupported")
+}

--- a/sse/encoder_test.go
+++ b/sse/encoder_test.go
@@ -21,6 +21,17 @@ func TestEncoder_Encode(t *testing.T) {
 		assert.Equal(t, expected, string(actual.Payload))
 	})
 
+	t.Run("without type + unwrap data", func(t *testing.T) {
+		getCoder := Encoder{UnwrapData: true}
+		msg := &common.Reply{Identifier: "test_channel", Message: "hello"}
+		expected := `data: hello`
+
+		actual, err := getCoder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
 	t.Run("with type", func(t *testing.T) {
 		msg := &common.Reply{Type: "test", Identifier: "test_channel", Message: "hello"}
 		expected := "event: test\n" +

--- a/sse/encoder_test.go
+++ b/sse/encoder_test.go
@@ -1,0 +1,104 @@
+package sse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/anycable/anycable-go/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncoder_Encode(t *testing.T) {
+	coder := Encoder{}
+
+	t.Run("without type", func(t *testing.T) {
+		msg := &common.Reply{Identifier: "test_channel", Message: "hello"}
+		expected := `data: {"identifier":"test_channel","message":"hello"}`
+
+		actual, err := coder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("with type", func(t *testing.T) {
+		msg := &common.Reply{Type: "test", Identifier: "test_channel", Message: "hello"}
+		expected := "event: test\n" +
+			`data: {"type":"test","identifier":"test_channel","message":"hello"}`
+
+		actual, err := coder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("with offset and stream id", func(t *testing.T) {
+		msg := &common.Reply{Type: "test", Identifier: "test_channel", Message: "hello", StreamID: "stream-test", Epoch: "bc320", Offset: 321}
+		expected := "event: test\n" +
+			`data: {"type":"test","identifier":"test_channel","message":"hello","stream_id":"stream-test","epoch":"bc320","offset":321}` + "\n" +
+			"id: 321/bc320/stream-test"
+
+		actual, err := coder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("when disconnect with reconnect=true", func(t *testing.T) {
+		msg := &common.Reply{Type: "disconnect", Reason: "unknown", Reconnect: true}
+		expected := "event: disconnect\n" +
+			`data: {"type":"disconnect","reason":"unknown","reconnect":true}`
+
+		actual, err := coder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("when disconnect with reconnect=false", func(t *testing.T) {
+		msg := &common.DisconnectMessage{Type: "disconnect", Reason: "unknown", Reconnect: false}
+		expected := "event: disconnect\n" +
+			`data: {"type":"disconnect","reason":"unknown","reconnect":false}` + "\n" +
+			"retry: " + fmt.Sprintf("%d", retryNoReconnect)
+
+		actual, err := coder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+}
+
+func TestEncoder_EncodeTransmission(t *testing.T) {
+	coder := Encoder{}
+
+	t.Run("w/type", func(t *testing.T) {
+		msg := "{\"type\":\"test\",\"identifier\":\"test_channel\",\"message\":\"hello\"}"
+		expected := []byte(fmt.Sprintf("event: test\ndata: %s", msg))
+
+		actual, err := coder.EncodeTransmission(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual.Payload)
+	})
+
+	t.Run("w/o type", func(t *testing.T) {
+		msg := "{\"message\":\"hello\"}"
+		expected := []byte(fmt.Sprintf("data: %s", msg))
+
+		actual, err := coder.EncodeTransmission(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual.Payload)
+	})
+}
+
+func TestEncoder_Decode(t *testing.T) {
+	coder := Encoder{}
+
+	msg := []byte("{\"command\":\"test\",\"identifier\":\"test_channel\",\"data\":\"hello\"}")
+
+	actual, err := coder.Decode(msg)
+
+	assert.Error(t, err)
+	assert.Nil(t, actual)
+}

--- a/sse/handler.go
+++ b/sse/handler.go
@@ -76,7 +76,7 @@ func SSEHandler(n *node.Node, shutdownCtx context.Context, headersExtractor serv
 		}
 
 		// Finally, we can establish a session
-		session, err := NewSSESession(n, w, info)
+		session, err := NewSSESession(n, w, r, info)
 
 		if err != nil {
 			sessionCtx.Errorf("failed to establish sesssion: %v", err)

--- a/sse/handler.go
+++ b/sse/handler.go
@@ -1,0 +1,148 @@
+package sse
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/server"
+	"github.com/anycable/anycable-go/version"
+	"github.com/anycable/anycable-go/ws"
+	"github.com/apex/log"
+)
+
+// SSEHandler generates a new http handler for SSE connections
+func SSEHandler(n *node.Node, headersExtractor server.HeadersExtractor, config *Config) http.Handler {
+	allowedHosts := strings.Split(config.AllowedOrigins, ",")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Write CORS headers
+		if config.AllowedOrigins == "" {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		} else {
+			origin := strings.ToLower(r.Header.Get("Origin"))
+			u, err := url.Parse(origin)
+			if err == nil {
+				for _, host := range allowedHosts {
+					if host[0] == '*' && strings.HasSuffix(u.Host, host[1:]) {
+						w.Header().Set("Access-Control-Allow-Origin", origin)
+					}
+					if u.Host == host {
+						w.Header().Set("Access-Control-Allow-Origin", origin)
+					}
+				}
+			}
+		}
+
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, X-Request-ID, Content-Type, Accept, X-CSRF-Token, Authorization")
+
+		// Respond to preflight requests
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// SSE only supports GET requests
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Prepare common headers
+		w.Header().Set("X-AnyCable-Version", version.Version())
+		if r.ProtoMajor == 1 {
+			// An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields.
+			// Source: RFC7540.
+			w.Header().Set("Connection", "keep-alive")
+		}
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.Header().Set("Cache-Control", "private, no-cache, no-store, must-revalidate, max-age=0") // HTTP 1.1
+		w.Header().Set("Pragma", "no-cache")                                                       // HTTP 1.0
+		w.Header().Set("Expire", "0")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			w.WriteHeader(http.StatusNotImplemented)
+			return
+		}
+
+		info, err := server.NewRequestInfo(r, headersExtractor)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		sessionCtx := log.WithField("sid", info.UID).WithField("transport", "sse")
+
+		subscribeCmd, err := subscribeCommandFromRequest(r)
+
+		if err != nil {
+			sessionCtx.Errorf("failed to build subscribe command: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Handle subscription
+		if subscribeCmd == nil {
+			sessionCtx.Error("no channel provided")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Finally, we can establish a session
+		session, err := NewSSESession(n, w, info)
+
+		if err != nil {
+			sessionCtx.Errorf("failed to establish sesssion: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if session == nil {
+			sessionCtx.Error("authentication failed")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		conn := session.UnderlyingConn().(*Connection)
+
+		// Subscribe to the channel
+		res, err := n.Subscribe(session, subscribeCmd)
+
+		if err != nil || res == nil {
+			sessionCtx.Errorf("failed to subscribe: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Subscription rejected
+		if res.Status != common.SUCCESS {
+			sessionCtx.Debugf("rejected: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		conn.Established()
+		sessionCtx.Debugf("session established")
+
+		// TODO: Handle server shutdown. Currently, server is waiting for SSE connections to be closed
+		select {
+		case <-r.Context().Done():
+			sessionCtx.Debugf("request terminated")
+			session.DisconnectNow("Closed", ws.CloseNormalClosure)
+			return
+		case <-conn.Context().Done():
+			sessionCtx.Debugf("session completed")
+			return
+		}
+	})
+}

--- a/sse/handler_test.go
+++ b/sse/handler_test.go
@@ -1,0 +1,250 @@
+package sse
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/anycable/anycable-go/broker"
+	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/metrics"
+	"github.com/anycable/anycable-go/mocks"
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/pubsub"
+	"github.com/anycable/anycable-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type streamingWriter struct {
+	httptest.ResponseRecorder
+
+	stream chan []byte
+}
+
+func newStreamingWriter(w *httptest.ResponseRecorder) *streamingWriter {
+	return &streamingWriter{
+		ResponseRecorder: *w,
+		stream:           make(chan []byte, 100),
+	}
+}
+
+func (w *streamingWriter) Write(data []byte) (int, error) {
+	events := bytes.Split(data, []byte("\n\n"))
+
+	for _, event := range events {
+		if len(event) > 0 {
+			w.stream <- event
+		}
+	}
+
+	return w.ResponseRecorder.Write(data)
+}
+
+func (w *streamingWriter) ReadEvent(ctx context.Context) (string, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case event := <-w.stream:
+			return string(event), nil
+		}
+	}
+}
+
+var _ http.ResponseWriter = (*streamingWriter)(nil)
+
+func TestSSEHandler(t *testing.T) {
+	appNode, controller := buildNode()
+	conf := NewConfig()
+
+	dconfig := node.NewDisconnectQueueConfig()
+	dconfig.Rate = 1
+	disconnector := node.NewDisconnectQueue(appNode, &dconfig)
+	appNode.SetDisconnector(disconnector)
+
+	go appNode.Start()                           // nolint: errcheck
+	defer appNode.Shutdown(context.Background()) // nolint: errcheck
+
+	headersExtractor := &server.DefaultHeadersExtractor{}
+
+	handler := SSEHandler(appNode, headersExtractor, &conf)
+
+	controller.
+		On("Shutdown").
+		Return(nil)
+
+	controller.
+		On("Disconnect", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	t.Run("headers", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, "text/event-stream; charset=utf-8", w.Header().Get("Content-Type"))
+		assert.Equal(t, "private, no-cache, no-store, must-revalidate, max-age=0", w.Header().Get("Cache-Control"))
+		assert.Equal(t, "no-cache", w.Header().Get("Pragma"))
+		assert.Equal(t, "keep-alive", w.Header().Get("Connection"))
+	})
+
+	t.Run("OPTIONS", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("OPTIONS", "/", nil)
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("non-GET/OPTIONS", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/", nil)
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("when authentication fails", func(t *testing.T) {
+		controller.
+			On("Authenticate", "sid-fail", mock.Anything).
+			Return(&common.ConnectResult{
+				Status:        common.FAILURE,
+				Transmissions: []string{`{"type":"disconnect"}`},
+			}, nil)
+
+		req, _ := http.NewRequest("GET", "/?channel=room_1", nil)
+		req.Header.Set("X-Request-ID", "sid-fail")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Empty(t, w.Body.String())
+	})
+
+	t.Run("request with identifier", func(t *testing.T) {
+		controller.
+			On("Authenticate", "sid-gut", mock.Anything).
+			Return(&common.ConnectResult{
+				Identifier:    "se2023",
+				Status:        common.SUCCESS,
+				Transmissions: []string{`{"type":"welcome"}`},
+			}, nil)
+
+		controller.
+			On("Subscribe", "sid-gut", mock.Anything, "se2023", "chat_1").
+			Return(&common.CommandResult{
+				Status:        common.SUCCESS,
+				Transmissions: []string{`{"type":"confirm","identifier":"chat_1"}`},
+				Streams:       []string{"messages_1"},
+			}, nil)
+
+		req, _ := http.NewRequest("GET", "/?identifier=chat_1", nil)
+		req.Header.Set("X-Request-ID", "sid-gut")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		sw := newStreamingWriter(w)
+
+		go handler.ServeHTTP(sw, req)
+
+		msg, err := sw.ReadEvent(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "event: welcome\n"+`data: {"type":"welcome"}`, msg)
+
+		msg, err = sw.ReadEvent(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "event: confirm\n"+`data: {"type":"confirm","identifier":"chat_1"}`, msg)
+
+		appNode.Broadcast(&common.StreamMessage{Stream: "messages_1", Data: `{"content":"hello"}`})
+
+		msg, err = sw.ReadEvent(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, `data: {"identifier":"chat_1","message":{"content":"hello"}}`, msg)
+
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("request with channel + rejected", func(t *testing.T) {
+		controller.
+			On("Authenticate", "sid-reject", mock.Anything).
+			Return(&common.ConnectResult{
+				Identifier:    "se2034",
+				Status:        common.SUCCESS,
+				Transmissions: []string{`{"type":"welcome"}`},
+			}, nil)
+
+		controller.
+			On("Subscribe", "sid-reject", mock.Anything, "se2034", `{"channel":"room_1"}`).
+			Return(&common.CommandResult{
+				Status:        common.FAILURE,
+				Transmissions: []string{`{"type":"reject","identifier":"room_1"}`},
+			}, nil)
+
+		req, _ := http.NewRequest("GET", "/?channel=room_1", nil)
+		req.Header.Set("X-Request-ID", "sid-reject")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Empty(t, w.Body.String())
+
+		controller.AssertCalled(t, "Subscribe", "sid-reject", mock.Anything, "se2034", `{"channel":"room_1"}`)
+	})
+
+	t.Run("request without channel or identifier", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/", nil)
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Empty(t, w.Body.String())
+	})
+}
+
+type immediateDisconnector struct {
+	n *node.Node
+}
+
+func (d *immediateDisconnector) Enqueue(s *node.Session) error {
+	return d.n.DisconnectNow(s)
+}
+
+func (immediateDisconnector) Run() error                         { return nil }
+func (immediateDisconnector) Shutdown(ctx context.Context) error { return nil }
+func (immediateDisconnector) Size() int                          { return 0 }
+
+func buildNode() (*node.Node, *mocks.Controller) {
+	controller := &mocks.Controller{}
+	config := node.NewConfig()
+	config.HubGopoolSize = 2
+	n := node.NewNode(controller, metrics.NewMetrics(nil, 10), &config)
+	n.SetBroker(broker.NewLegacyBroker(pubsub.NewLegacySubscriber(n)))
+	n.SetDisconnector(&immediateDisconnector{n})
+	return n, controller
+}

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -1,12 +1,17 @@
 package sse
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/anycable/anycable-go/common"
 	"github.com/anycable/anycable-go/node"
 	"github.com/anycable/anycable-go/server"
 	"github.com/anycable/anycable-go/utils"
+	"github.com/joomcode/errorx"
 )
 
 func NewSSESession(n *node.Node, w http.ResponseWriter, info *server.RequestInfo) (*node.Session, error) {
@@ -27,7 +32,26 @@ func NewSSESession(n *node.Node, w http.ResponseWriter, info *server.RequestInfo
 }
 
 // Extract channel identifier or name from the request and build a subscribe command payload
-func subscribeCommandFromRequest(r *http.Request) (*common.Message, error) {
+func subscribeCommandsFromRequest(r *http.Request) ([]*common.Message, error) {
+	if r.Method == http.MethodGet {
+		cmd, err := subscribeCommandFromGetRequest(r)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if cmd == nil {
+			return nil, errors.New("no channel provided")
+		}
+
+		return []*common.Message{cmd}, nil
+
+	} else {
+		return subscribeCommandFromPostRequest(r)
+	}
+}
+
+func subscribeCommandFromGetRequest(r *http.Request) (*common.Message, error) {
 	msg := &common.Message{
 		Command: "subscribe",
 	}
@@ -50,4 +74,37 @@ func subscribeCommandFromRequest(r *http.Request) (*common.Message, error) {
 	msg.Identifier = identifier
 
 	return msg, nil
+}
+
+func subscribeCommandFromPostRequest(r *http.Request) ([]*common.Message, error) {
+	var cmds []*common.Message
+
+	// Read commands (if any)
+	if r.Body != nil {
+		r.Body = http.MaxBytesReader(nil, r.Body, int64(defaultMaxBodySize))
+		requestData, err := io.ReadAll(r.Body)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(requestData) > 0 {
+			lines := bytes.Split(requestData, []byte("\n"))
+
+			for _, line := range lines {
+				if len(line) > 0 {
+					var command common.Message
+					err := json.Unmarshal(line, &command)
+
+					if err != nil {
+						return nil, errorx.Decorate(err, "failed to parse command: %v", command)
+					}
+
+					cmds = append(cmds, &command)
+				}
+			}
+		}
+	}
+
+	return cmds, nil
 }

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -1,0 +1,53 @@
+package sse
+
+import (
+	"net/http"
+
+	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/node"
+	"github.com/anycable/anycable-go/server"
+	"github.com/anycable/anycable-go/utils"
+)
+
+func NewSSESession(n *node.Node, w http.ResponseWriter, info *server.RequestInfo) (*node.Session, error) {
+	conn := NewConnection(w)
+
+	session := node.NewSession(n, conn, info.URL, info.Headers, info.UID, node.WithEncoder(&Encoder{}))
+	res, err := n.Authenticate(session)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Status == common.SUCCESS {
+		return session, nil
+	} else {
+		return nil, nil
+	}
+}
+
+// Extract channel identifier or name from the request and build a subscribe command payload
+func subscribeCommandFromRequest(r *http.Request) (*common.Message, error) {
+	msg := &common.Message{
+		Command: "subscribe",
+	}
+
+	// First, check if identifier is provided
+	identifier := r.URL.Query().Get("identifier")
+
+	if identifier == "" {
+		channel := r.URL.Query().Get("channel")
+
+		if channel != "" {
+			identifier = string(utils.ToJSON(map[string]string{"channel": channel}))
+		}
+	}
+
+	if identifier == "" {
+		return nil, nil
+	}
+
+	msg.Identifier = identifier
+
+	return msg, nil
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

This PR brings Server-Sent Events support to AnyCable making it possible to subscribe to Action Cable channel updates via EventSource or pure HTTP.

One of the primary use cases is to use Turbo Streams without Action Cable on the client side:

```html
<turbo-stream-source src="http://localhost:8080/events?turbo_signed_stream_name=chat_1" />
```

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
