### PR TITLE
Add support for REDIS_URL with trailing slash hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Add support for REDIS_URL with trailing slash hostnames. ([@ardecvz][])
+
+`rueidis` doesn't tolerate the trailing slash hostnames.
+
 - Support to use a custom database number. ([@ardecvz][])
 
 Parse `--redis_url` (`ANYCABLE_REDIS_URL` or `REDIS_URL`) using the `rueidis` standard utility.

--- a/redis/config.go
+++ b/redis/config.go
@@ -120,6 +120,8 @@ func parseRedisURL(url string) (options *rueidis.ClientOption, err error) {
 	urls := strings.Split(url, ",")
 
 	for _, addr := range urls {
+		addr = chompTrailingSlashHostname(addr)
+
 		currentOptions, err := rueidis.ParseURL(ensureRedisScheme(addr))
 
 		if err != nil {
@@ -134,6 +136,12 @@ func parseRedisURL(url string) (options *rueidis.ClientOption, err error) {
 	}
 
 	return options, nil
+}
+
+// TODO: upstream this change to `rueidis` URL parsing
+// as the implementation doesn't tolerate the trailing slash hostnames (`redis-cli` does).
+func chompTrailingSlashHostname(url string) string {
+	return strings.TrimSuffix(url, "/")
 }
 
 func ensureRedisScheme(url string) string {

--- a/redis/config_test.go
+++ b/redis/config_test.go
@@ -27,6 +27,15 @@ func TestBasic(t *testing.T) {
 	assert.Nil(t, options.TLSConfig)
 }
 
+func TestTrailingSlashHostname(t *testing.T) {
+	config := NewRedisConfig()
+	config.URL = "redis://localhost:6379/"
+	options, err := config.ToRueidisOptions()
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, options.SelectDB)
+}
+
 func TestCustomDatabase(t *testing.T) {
 	config := NewRedisConfig()
 	config.URL = "redis://localhost:6379/1"

--- a/redis/config_test.go
+++ b/redis/config_test.go
@@ -33,6 +33,7 @@ func TestTrailingSlashHostname(t *testing.T) {
 	options, err := config.ToRueidisOptions()
 	require.NoError(t, err)
 
+	assert.Equal(t, []string{"localhost:6379"}, options.InitAddress)
 	assert.Equal(t, 0, options.SelectDB)
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?
Add support for REDIS_URL with trailing slash hostnames (`redis://localhost:6379/`)
### What changes did you make? (overview)
Chomp trailing slash in the hostname
### Is there anything you'd like reviewers to focus on?
Upstream this change to `rueidis` URL parsing as the implementation doesn't tolerate the trailing slash hostnames (`redis-cli` does).
### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
