### PR TITLE
Return support for an scheme omitted IP address in RPC_HOST 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+- Return support for an scheme omitted IP address in RPC_HOST. ([@ardecvz][])
+
+For example, `127.0.0.1:50051/anycable`.
+
+It's missing from 1.4.6 which introduced auto RPC implementation inferring from the RPC host.
+
 ## 1.4.7
 
 - Add NATS-based broker. ([@palkan][])

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	pb "github.com/anycable/anycable-go/protos"
 )
@@ -73,10 +74,10 @@ func (c *Config) Impl() string {
 		return c.Implementation
 	}
 
-	uri, err := url.Parse(c.Host)
+	uri, err := url.Parse(ensureGrpcScheme(c.Host))
 
 	if err != nil {
-		return "<invalid rpc host>"
+		return fmt.Sprintf("<invalid RPC host: %s>", c.Host)
 	}
 
 	if uri.Scheme == "http" || uri.Scheme == "https" {
@@ -125,4 +126,12 @@ func (c *Config) TLSConfig() (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+func ensureGrpcScheme(url string) string {
+	if strings.Contains(url, "://") {
+		return url
+	}
+
+	return "grpc://" + url
 }

--- a/rpc/config_test.go
+++ b/rpc/config_test.go
@@ -16,7 +16,6 @@ func TestConfig_Impl(t *testing.T) {
 	assert.Equal(t, "trpc", c.Impl())
 
 	c.Implementation = ""
-
 	assert.Equal(t, "grpc", c.Impl())
 
 	c.Host = "http://localhost:8080/anycable"
@@ -28,6 +27,15 @@ func TestConfig_Impl(t *testing.T) {
 	c.Host = "grpc://localhost:50051/anycable"
 	assert.Equal(t, "grpc", c.Impl())
 
+	c.Host = "dns:///rpc:50051"
+	assert.Equal(t, "grpc", c.Impl())
+
 	c.Host = "localhost:50051/anycable"
 	assert.Equal(t, "grpc", c.Impl())
+
+	c.Host = "127.0.0.1:50051/anycable"
+	assert.Equal(t, "grpc", c.Impl())
+
+	c.Host = "invalid://:+"
+	assert.Equal(t, "<invalid RPC host: invalid://:+>", c.Impl())
 }


### PR DESCRIPTION
### What is the purpose of this pull request?
Return support for an scheme omitted IP address in RPC_HOST 

For example, `127.0.0.1:50051/anycable`.

It's missing from 1.4.6 which introduced auto RPC implementation
inferring from the RPC host.

### What changes did you make? (overview)
Default to grpc:// scheme if omitted + test all known RPC_HOST variants + include invalid RPC_HOST to logs for better debugging:
`!!! RPC failed !!!, cause: unknown RPC implementation: <invalid RPC host: invalid://:+>` 

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
