### PR TITLE
Whispering

### DIFF
--- a/broadcast/http.go
+++ b/broadcast/http.go
@@ -137,7 +137,7 @@ func (s *HTTPBroadcaster) Start(done chan (error)) error {
 	}
 
 	if s.enableCORS {
-		verifiedVia = verifiedVia + ", CORS enabled"
+		verifiedVia += ", CORS enabled"
 	}
 
 	s.log.Info(fmt.Sprintf("Accept broadcast requests at %s%s (%s)", s.server.Address(), s.path, verifiedVia))

--- a/broker/memory.go
+++ b/broker/memory.go
@@ -234,6 +234,11 @@ func (b *Memory) Shutdown(ctx context.Context) error {
 }
 
 func (b *Memory) HandleBroadcast(msg *common.StreamMessage) {
+	if msg.Meta != nil && msg.Meta.Transient {
+		b.broadcaster.Broadcast(msg)
+		return
+	}
+
 	offset := b.add(msg.Stream, msg.Data)
 
 	msg.Epoch = b.GetEpoch()

--- a/broker/nats.go
+++ b/broker/nats.go
@@ -311,6 +311,11 @@ func (n *NATS) writeEpoch(val string) {
 }
 
 func (n *NATS) HandleBroadcast(msg *common.StreamMessage) {
+	if msg.Meta != nil && msg.Meta.Transient {
+		n.broadcaster.Broadcast(msg)
+		return
+	}
+
 	err := n.Ready(jetstreamReadyTimeout)
 	if err != nil {
 		n.log.Debug("JetStream is not ready yet to publish messages, add to backlog")

--- a/cli/options.go
+++ b/cli/options.go
@@ -1097,6 +1097,12 @@ func signedStreamsCLIFlags(c *config.Config, turboRailsKey *string, cableReadyKe
 		},
 
 		&cli.BoolFlag{
+			Name:        "streams_whisper",
+			Usage:       "Enable whispering for signed pub/sub streams",
+			Destination: &c.Streams.Whisper,
+		},
+
+		&cli.BoolFlag{
 			Name:        "turbo_streams",
 			Usage:       "Enable Turbo Streams support",
 			Destination: &c.Streams.Turbo,

--- a/common/common.go
+++ b/common/common.go
@@ -289,6 +289,10 @@ func (m *Message) LogValue() slog.Value {
 // which can be used to modify delivery behavior
 type StreamMessageMetadata struct {
 	ExcludeSocket string `json:"exclude_socket,omitempty"`
+	// BroadcastType defines the message type to be used for messages sent to clients
+	BroadcastType string `json:"broadcast_type,omitempty"`
+	// Transient defines whether this message should be stored in the history
+	Transient bool `json:"transient,omitempty"`
 }
 
 func (smm *StreamMessageMetadata) LogValue() slog.Value {

--- a/common/common.go
+++ b/common/common.go
@@ -64,6 +64,8 @@ const (
 
 	HistoryConfirmedType = "confirm_history"
 	HistoryRejectedType  = "reject_history"
+
+	WhisperType = "whisper"
 )
 
 // Disconnect reasons
@@ -73,6 +75,11 @@ const (
 	IDLE_TIMEOUT_REASON      = "idle_timeout"
 	NO_PONG_REASON           = "no_pong"
 	UNAUTHORIZED_REASON      = "unauthorized"
+)
+
+// Reserver state fields
+const (
+	WHISPER_STATE_SUFFIX = "$w"
 )
 
 // SessionEnv represents the underlying HTTP connection data:
@@ -513,4 +520,9 @@ func RejectionMessage(identifier string) string {
 // DisconnectionMessage returns a disconnect message with the specified reason and reconnect flag
 func DisconnectionMessage(reason string, reconnect bool) string {
 	return string(utils.ToJSON(DisconnectMessage{Type: DisconnectType, Reason: reason, Reconnect: reconnect}))
+}
+
+// WhisperStateKey returns the field name for the given identifier to store the whispering stream name
+func WhisperStateKey(identifier string) string {
+	return identifier + "/" + WHISPER_STATE_SUFFIX
 }

--- a/common/common.go
+++ b/common/common.go
@@ -79,7 +79,7 @@ const (
 
 // Reserver state fields
 const (
-	WHISPER_STATE_SUFFIX = "$w"
+	WHISPER_STREAM_STATE = "$w"
 )
 
 // SessionEnv represents the underlying HTTP connection data:
@@ -133,6 +133,10 @@ func (st *SessionEnv) MergeChannelState(id string, other *map[string]string) {
 			(*st.ChannelStates)[id][k] = v
 		}
 	}
+}
+
+func (st *SessionEnv) RemoveChannelState(id string) {
+	delete((*st.ChannelStates), id)
 }
 
 // Returns a value for the specified key of the specified channel
@@ -520,9 +524,4 @@ func RejectionMessage(identifier string) string {
 // DisconnectionMessage returns a disconnect message with the specified reason and reconnect flag
 func DisconnectionMessage(reason string, reconnect bool) string {
 	return string(utils.ToJSON(DisconnectMessage{Type: DisconnectType, Reason: reason, Reconnect: reconnect}))
-}
-
-// WhisperStateKey returns the field name for the given identifier to store the whispering stream name
-func WhisperStateKey(identifier string) string {
-	return identifier + "/" + WHISPER_STATE_SUFFIX
 }

--- a/docs/signed_streams.md
+++ b/docs/signed_streams.md
@@ -142,6 +142,27 @@ $digest = hash_hmac('sha256', $encoded, $SECRET_KEY);
 $signed_stream_name = $encoded . '--' . $digest;
 ```
 
+## Whispering
+
+_Whispering_ is an ability to publish _transient_ broadcasts from clients, i.e., without touching your backend. This is useful when you want to share client-only information from one connection to others. Typical examples include typing indicators, cursor position sharing, etc.
+
+Whispering must be enabled explicitly for signed streams via the `--streams_whisper` (`ANYCABLE_STREAMS_WHISPER=true`) option. Public streams always allow whispering.
+
+Here is an example client code using AnyCable JS SDK:
+
+```js
+let channel = cable.streamFrom("chat/22");
+
+channel.on("message", (msg) => {
+  if (msg.event === "typing") {
+    console.log(`user ${msg.name} is typing`);
+  }
+})
+
+// publishing whispers
+channel.whisper({event: "typing", name: user.name})
+```
+
 ## Hotwire and CableReady support
 
 AnyCable provides an ability to terminate Hotwire ([Turbo Streams](https://turbo.hotwired.dev/handbook/streams)) and [CableReady](https://cableready.stimulusreflex.com) (v5+) subscriptions at the WebSocker server using the same signed streams functionality under the hood (and, thus, without performing any RPC calls to authorize subscriptions).

--- a/etc/anyt/broadcast_tests/whisper_test.rb
+++ b/etc/anyt/broadcast_tests/whisper_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+feature "Whisper" do
+  channel do
+    def subscribed
+      stream_from "a"
+      # whispers_to "a" ???
+      __istate__["$w"] = "a"
+    end
+  end
+
+  let(:client2) { build_client(ignore: %w[ping welcome]) }
+  let(:client3) { build_client(ignore: %w[ping welcome]) }
+
+  before do
+    subscribe_request = {command: "subscribe", identifier: {channel: channel}.to_json}
+
+    client.send(subscribe_request)
+    client2.send(subscribe_request)
+    client3.send(subscribe_request)
+
+    ack = {
+      "identifier" => {channel: channel}.to_json, "type" => "confirm_subscription"
+    }
+
+    assert_message ack, client.receive
+    assert_message ack, client2.receive
+    assert_message ack, client3.receive
+  end
+
+  scenario %(
+    Only other clients receive the whisper message
+  ) do
+    perform_request = {
+      :command => "whisper",
+      :identifier => {channel: channel}.to_json,
+      "data" => {"event" => "typing", "user" => "Vova"}
+    }
+
+    client.send(perform_request)
+
+    msg = {"type" => "whisper", "identifier" => {channel: channel}.to_json, "message" => {"event" => "typing", "user" => "Vova"}}
+
+    assert_message msg, client2.receive
+    assert_message msg, client3.receive
+    assert_raises(Anyt::Client::TimeoutError) do
+      msg = client.receive(timeout: 0.5)
+      raise "Client 1 should not receive the message: #{msg}"
+    end
+  end
+end

--- a/etc/anyt/broadcast_tests/whisper_test.rb
+++ b/etc/anyt/broadcast_tests/whisper_test.rb
@@ -39,7 +39,7 @@ feature "Whisper" do
 
     client.send(perform_request)
 
-    msg = {"type" => "whisper", "identifier" => {channel: channel}.to_json, "message" => {"event" => "typing", "user" => "Vova"}}
+    msg = {"identifier" => {channel: channel}.to_json, "message" => {"event" => "typing", "user" => "Vova"}}
 
     assert_message msg, client2.receive
     assert_message msg, client3.receive

--- a/hub/gate.go
+++ b/hub/gate.go
@@ -162,7 +162,13 @@ func (g *Gate) performBroadcast(streamMsg *common.StreamMessage) {
 }
 
 func buildMessage(msg *common.StreamMessage, identifier string) encoders.EncodedMessage {
-	return encoders.NewCachedEncodedMessage(msg.ToReplyFor(identifier))
+	reply := msg.ToReplyFor(identifier)
+
+	if msg.Meta != nil {
+		reply.Type = msg.Meta.BroadcastType
+	}
+
+	return encoders.NewCachedEncodedMessage(reply)
 }
 
 func streamSessionsSnapshot[T comparable](src map[T]map[string]bool) map[T][]string {

--- a/node/broker_integration_test.go
+++ b/node/broker_integration_test.go
@@ -310,6 +310,8 @@ func sharedIntegrationHistory(t *testing.T, node *Node, controller *mocks.Contro
 	ts := time.Now().Unix()
 
 	node.HandleBroadcast([]byte(`{"stream": "messages_1","data":"Flavia: buona sera"}`))
+	// Transient messages must not be stored in the history
+	node.HandleBroadcast([]byte(`{"stream": "messages_1","data":"Who's there?","meta":{"transient":true}}`))
 	node.HandleBroadcast([]byte(`{"stream": "messages_1","data":"Mario: ta-dam!"}`))
 
 	node.HandleBroadcast([]byte(`{"stream": "presence_1","data":"1 new notification"}`))

--- a/node/node.go
+++ b/node/node.go
@@ -653,7 +653,6 @@ func (n *Node) Whisper(s *Session, msg *common.Message) error {
 		Data:   string(utils.ToJSON(msg.Data)),
 		Meta: &common.StreamMessageMetadata{
 			ExcludeSocket: s.GetID(),
-			BroadcastType: common.WhisperType,
 			Transient:     true,
 		},
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -494,6 +494,7 @@ func (n *Node) Unsubscribe(s *Session, msg *common.Message) (*common.CommandResu
 		// Make sure to remove all streams subscriptions
 		res.StopAllStreams = true
 
+		s.env.RemoveChannelState(msg.Identifier)
 		s.subscriptions.RemoveChannel(msg.Identifier)
 
 		s.Log.Debug("unsubscribed", "identifier", msg.Identifier)
@@ -640,17 +641,10 @@ func (n *Node) Whisper(s *Session, msg *common.Message) error {
 		return errors.New("session environment is missing")
 	}
 
-	streamVal, ok := s.ReadInternalState(common.WhisperStateKey(msg.Identifier))
+	stream := env.GetChannelStateField(msg.Identifier, common.WHISPER_STREAM_STATE)
 
-	if !ok {
+	if stream == "" {
 		s.Log.Debug("whisper stream not found", "identifier", msg.Identifier)
-		return nil
-	}
-
-	stream, ok := streamVal.(string)
-
-	if !ok {
-		s.Log.Warn("whisper stream is not a string", "identifier", msg.Identifier, "value", streamVal)
 		return nil
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -272,7 +272,7 @@ func TestWhisper(t *testing.T) {
 	defer node.hub.Shutdown()
 
 	t.Run("When whispering stream is configured for sending subscription", func(t *testing.T) {
-		session.WriteInternalState(common.WhisperStateKey("test_channel"), "test_whisper")
+		session.env.MergeChannelState("test_channel", &map[string]string{common.WHISPER_STREAM_STATE: "test_whisper"})
 
 		err := node.Whisper(session, &common.Message{Identifier: "test_channel", Data: "tshh... it's a secret"})
 		assert.Nil(t, err)
@@ -290,7 +290,7 @@ func TestWhisper(t *testing.T) {
 	})
 
 	t.Run("When whispering stream is not configured", func(t *testing.T) {
-		session.InternalState = make(map[string]interface{})
+		session.env.RemoveChannelState("test_channel")
 
 		err := node.Whisper(session, &common.Message{Identifier: "test_channel", Data: "tshh... it's a secret"})
 		assert.Nil(t, err)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -277,7 +277,7 @@ func TestWhisper(t *testing.T) {
 		err := node.Whisper(session, &common.Message{Identifier: "test_channel", Data: "tshh... it's a secret"})
 		assert.Nil(t, err)
 
-		expected := `{"type":"whisper","identifier":"test_channel_2","message":"tshh... it's a secret"}`
+		expected := `{"identifier":"test_channel_2","message":"tshh... it's a secret"}`
 
 		msg, err := session2.conn.Read()
 		assert.NoError(t, err)

--- a/streams/config.go
+++ b/streams/config.go
@@ -9,6 +9,9 @@ type Config struct {
 	// Public determines if public (unsigned) streams are allowed
 	Public bool
 
+	// Whisper determines if whispering is enabled for pub/sub streams
+	Whisper bool
+
 	// PubSubChannel is the channel name used for direct pub/sub
 	PubSubChannel string
 

--- a/streams/controller_test.go
+++ b/streams/controller_test.go
@@ -53,6 +53,7 @@ func TestStreamsController(t *testing.T) {
 		assert.Equal(t, []string{common.ConfirmationMessage(`{"channel":"$pubsub","stream_name":"chat:2024"}`)}, res.Transmissions)
 		assert.Equal(t, []string{"chat:2024"}, res.Streams)
 		assert.Equal(t, -1, res.DisconnectInterest)
+		assert.Equal(t, "chat:2024", res.IState[common.WHISPER_STREAM_STATE])
 	})
 
 	t.Run("Subscribe - no public allowed", func(t *testing.T) {
@@ -85,6 +86,28 @@ func TestStreamsController(t *testing.T) {
 		assert.Equal(t, []string{common.ConfirmationMessage(identifier)}, res.Transmissions)
 		assert.Equal(t, []string{"chat:2021"}, res.Streams)
 		assert.Equal(t, -1, res.DisconnectInterest)
+		assert.Nil(t, res.IState)
+	})
+
+	t.Run("Subscribe - signed - whisper", func(t *testing.T) {
+		conf := NewConfig()
+		conf.Secret = key
+		conf.Whisper = true
+		subject := NewStreamsController(&conf, slog.Default())
+
+		require.NotNil(t, subject)
+
+		identifier := `{"channel":"$pubsub","signed_stream_name":"` + stream + `"}`
+
+		res, err := subject.Subscribe("42", nil, "name=jack", identifier)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, common.SUCCESS, res.Status)
+		assert.Equal(t, []string{common.ConfirmationMessage(identifier)}, res.Transmissions)
+		assert.Equal(t, []string{"chat:2021"}, res.Streams)
+		assert.Equal(t, -1, res.DisconnectInterest)
+		assert.Equal(t, "chat:2021", res.IState[common.WHISPER_STREAM_STATE])
 	})
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Add new `whisper` command support to publish messages from clients without using a server.

Inspired by [Laravel Echo](https://laravel.com/docs/11.x/broadcasting#client-events).

### What changes did you make? (overview)

- Added `node.Whisper()` method to process `"type":"whisper"`  commands
- Added support for transient broadcast messages (not stored in the history)
- Added whispering support to pub/sub streams.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
